### PR TITLE
Activity/ROI improvements

### DIFF
--- a/BecquerelMonitor/BecquerelMonitor.csproj
+++ b/BecquerelMonitor/BecquerelMonitor.csproj
@@ -613,6 +613,7 @@
       <DependentUpon>CalibrationGraph.cs</DependentUpon>
     </Compile>
     <Compile Include="Utils\CalibrationSolver.cs" />
+    <Compile Include="Utils\ROIAriphmetics.cs" />
     <Compile Include="Utils\SpectrumAriphmetics.cs" />
     <Compile Include="Utils\WineCheck.cs" />
     <Compile Include="VerticalFittingMode.cs" />

--- a/BecquerelMonitor/EnergySpectrumView.Designer.cs
+++ b/BecquerelMonitor/EnergySpectrumView.Designer.cs
@@ -3152,16 +3152,24 @@ namespace BecquerelMonitor
         void ShowCursorValues(Graphics g)
         {
             int table_width_origin = 230;
-            int table_width_rel;
+            int channel_table_x_pos;
+            int region_table_x_pos;
+            bool isRegionSelected = this.selectionStart != -1 && this.selectionEnd != -1;
             if (this.cursorX < base.Width - (table_width_origin + 40))
             {
-                table_width_rel = this.left + this.width - table_width_origin - 10;
+                region_table_x_pos = this.left + this.width - table_width_origin - 10;
+                channel_table_x_pos = isRegionSelected 
+                    ? region_table_x_pos - table_width_origin - 10
+                    : region_table_x_pos;
             }
             else
             {
-                table_width_rel = this.left + 10;
+                region_table_x_pos = this.left + 10;
+                channel_table_x_pos = isRegionSelected
+                    ? region_table_x_pos + table_width_origin + 10
+                    : region_table_x_pos;
             }
-            int num3 = 10;
+            int table_y_pos = 10;
             ColorConfig colorConfig = this.globalConfigManager.GlobalConfig.ColorConfig;
             if (this.validCursor && this.cursorChannel >= 0 &&
                 this.cursorChannel < this.energySpectrum.NumberOfChannels &&
@@ -3221,10 +3229,10 @@ namespace BecquerelMonitor
                 {
                     num6 += 32;
                 }
-                g.FillRectangle(Brushes.DarkGray, table_width_rel, num3, table_width_origin, num6);
-                g.FillRectangle(Brushes.White, table_width_rel - 3, num3 - 3, table_width_origin, num6);
-                g.DrawRectangle(Pens.Black, table_width_rel - 3, num3 - 3, table_width_origin, num6);
-                Rectangle r = new Rectangle(table_width_rel + 5, num3 + 4, table_width_origin - 12, 32);
+                g.FillRectangle(Brushes.DarkGray, channel_table_x_pos, table_y_pos, table_width_origin, num6);
+                g.FillRectangle(Brushes.White, channel_table_x_pos - 3, table_y_pos - 3, table_width_origin, num6);
+                g.DrawRectangle(Pens.Black, channel_table_x_pos - 3, table_y_pos - 3, table_width_origin, num6);
+                Rectangle r = new Rectangle(channel_table_x_pos + 5, table_y_pos + 4, table_width_origin - 12, 32);
                 g.DrawString(Resources.ChartHeaderChannel, this.Font, Brushes.Black, r);
                 g.DrawString(this.cursorChannel.ToString(), this.Font, Brushes.Black, r, this.farFormat);
                 r.Y += 16;
@@ -3273,11 +3281,6 @@ namespace BecquerelMonitor
                         g.DrawString(Resources.ChartHeaderCountBGRatio, this.Font, Brushes.Black, r);
                         g.DrawString(num11.ToString("f2") + Resources.PercentCharacter, this.Font, Brushes.Black, r, this.farFormat);
                     }
-                }
-                num3 = 110;
-                if (this.backgroundEnergySpectrum == null || this.backgroundMode == BackgroundMode.Substract)
-                {
-                    num3 -= 32;
                 }
             }
             if (this.selectionStart != -1 && this.energySpectrum.NumberOfChannels > Math.Max(this.selectionStart, this.selectionEnd))
@@ -3430,10 +3433,10 @@ namespace BecquerelMonitor
                 {
                     infopanel_height += 54;
                 }
-                g.FillRectangle(Brushes.DarkGray, table_width_rel, num3, table_width_origin, infopanel_height);
-                g.FillRectangle(Brushes.White, table_width_rel - 3, num3 - 3, table_width_origin, infopanel_height);
-                g.DrawRectangle(Pens.Black, table_width_rel - 3, num3 - 3, table_width_origin, infopanel_height);
-                Rectangle r2 = new Rectangle(table_width_rel + 5, num3 + 4, table_width_origin - 12, 32);
+                g.FillRectangle(Brushes.DarkGray, region_table_x_pos, table_y_pos, table_width_origin, infopanel_height);
+                g.FillRectangle(Brushes.White, region_table_x_pos - 3, table_y_pos - 3, table_width_origin, infopanel_height);
+                g.DrawRectangle(Pens.Black, region_table_x_pos - 3, table_y_pos - 3, table_width_origin, infopanel_height);
+                Rectangle r2 = new Rectangle(region_table_x_pos + 5, table_y_pos + 4, table_width_origin - 12, 32);
                 g.DrawString(Resources.ChartHeaderSelection, this.Font, Brushes.Black, r2);
                 r2.Y += 22;
                 g.DrawLine(Pens.LightGray, r2.Left, r2.Top - 6, r2.Right, r2.Top - 6);

--- a/BecquerelMonitor/Properties/Resources.Designer.cs
+++ b/BecquerelMonitor/Properties/Resources.Designer.cs
@@ -220,6 +220,24 @@ namespace BecquerelMonitor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bq/kg.
+        /// </summary>
+        internal static string Bqkg {
+            get {
+                return ResourceManager.GetString("Bqkg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bq/l.
+        /// </summary>
+        internal static string Bql {
+            get {
+                return ResourceManager.GetString("Bql", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Refresh.
         /// </summary>
         internal static string ButtonRefresh {

--- a/BecquerelMonitor/Properties/Resources.resx
+++ b/BecquerelMonitor/Properties/Resources.resx
@@ -41951,4 +41951,10 @@ see peak in spectrum now).</value>
   <data name="Bq" xml:space="preserve">
     <value>Bq</value>
   </data>
+  <data name="Bqkg" xml:space="preserve">
+    <value>Bq/kg</value>
+  </data>
+  <data name="Bql" xml:space="preserve">
+    <value>Bq/l</value>
+  </data>
 </root>

--- a/BecquerelMonitor/Properties/Resources.ru.resx
+++ b/BecquerelMonitor/Properties/Resources.ru.resx
@@ -138,6 +138,12 @@
   <data name="BackgroundSelectionDialogTitle" xml:space="preserve">
     <value>Выберите файл фонового спектра</value>
   </data>
+  <data name="Bqkg" xml:space="preserve">
+    <value>Бк/кг</value>
+  </data>
+  <data name="Bql" xml:space="preserve">
+    <value>Бк/л</value>
+  </data>
   <data name="ButtonRefresh" xml:space="preserve">
     <value>Обновить</value>
   </data>

--- a/BecquerelMonitor/ROIConfigForm.cs
+++ b/BecquerelMonitor/ROIConfigForm.cs
@@ -1,4 +1,5 @@
 ﻿using BecquerelMonitor.Properties;
+using BecquerelMonitor.Utils;
 using ColorComboBox;
 using System;
 using System.Drawing;
@@ -451,6 +452,7 @@ namespace BecquerelMonitor
             roiprimitiveData.PrimitiveType = roiprimitiveDefinition.Name;
             roiprimitiveData.Operation = roiprimitiveOperation;
             roiprimitiveData.OperationType = roiprimitiveOperation.Name;
+            roiprimitiveData.InitFromDefinition(this.activeROIDefinition);
             this.activeROIDefinition.ROIPrimitives.Add(roiprimitiveData);
             this.ShowPrimitiveList(this.activeROIDefinition);
             this.ListupROIDefinitions(this.activeROIConfig);
@@ -919,7 +921,6 @@ namespace BecquerelMonitor
             {
                 return;
             }
-            double energy = nuclideDefinition.Energy;
             double num = (double)this.numericUpDown1.Value / 100.0;
             ROIDefinitionData roidefinitionData = new ROIDefinitionData();
             roidefinitionData.Name = nuclideDefinition.Name;
@@ -927,6 +928,21 @@ namespace BecquerelMonitor
             roidefinitionData.LowerLimit = Math.Floor(nuclideDefinition.Energy - nuclideDefinition.Energy * num / 2.0);
             roidefinitionData.UpperLimit = Math.Round(nuclideDefinition.Energy + nuclideDefinition.Energy * num / 2.0);
             roidefinitionData.HalfLife = nuclideDefinition.HalfLife;
+            roidefinitionData.Intencity = nuclideDefinition.Intencity;
+            if (this.activeROIConfig.HasEfficiency && nuclideDefinition.Intencity > 0)
+            {
+                ROIAriphmetics roiAriphmetics = new ROIAriphmetics(this.activeROIConfig);
+                ROIEfficiencyData effData = roiAriphmetics.CalculateEfficiency(nuclideDefinition.Energy);
+                if (effData != null && effData.Efficiency > 0)
+                {
+                    roidefinitionData.BecquerelCoefficient = (1 / effData.Efficiency) / (nuclideDefinition.Intencity / 100);
+                    if (effData.ErrorPercent > 0)
+                    {
+                        roidefinitionData.BecquerelCoefficientError = roidefinitionData.BecquerelCoefficient * (effData.ErrorPercent / 100);
+                    }
+                }
+            }
+
             this.activeROIConfig.ROIDefinitions.Add(roidefinitionData);
             this.ListupROIDefinitions(this.activeROIConfig);
             this.SetActiveROIConfigDirty();

--- a/BecquerelMonitor/ROIConfigForm.resx
+++ b/BecquerelMonitor/ROIConfigForm.resx
@@ -562,7 +562,7 @@
     <value>Color</value>
   </data>
   <data name="label22.Location" type="System.Drawing.Point, System.Drawing">
-    <value>410, 10</value>
+    <value>432, 10</value>
   </data>
   <data name="comboBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>112, 20</value>
@@ -595,7 +595,7 @@
     <value>100, 12</value>
   </data>
   <data name="comboBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 20</value>
+    <value>100, 20</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
     <value>25, 12</value>
@@ -697,7 +697,7 @@
     <value>True</value>
   </data>
   <data name="label23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>525, 10</value>
+    <value>535, 10</value>
   </data>
   <data name="numericUpDown1.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -778,7 +778,7 @@
     <value>99, 143</value>
   </data>
   <data name="button9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>448, 5</value>
+    <value>468, 5</value>
   </data>
   <data name="doubleTextBox1.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
@@ -940,7 +940,7 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="label21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 10</value>
+    <value>281, 10</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1396,7 +1396,7 @@
     <value>21</value>
   </data>
   <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>660, 10</value>
+    <value>670, 10</value>
   </data>
   <data name="table3.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 35</value>
@@ -1501,7 +1501,7 @@
     <value>36</value>
   </data>
   <data name="comboBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 7</value>
+    <value>325, 7</value>
   </data>
   <data name="&gt;&gt;textBox3.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1615,7 +1615,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="button10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>140, 6</value>
+    <value>140, 7</value>
   </data>
   <data name="&gt;&gt;label6.Name" xml:space="preserve">
     <value>label6</value>
@@ -1849,7 +1849,7 @@
     <value>Operation</value>
   </data>
   <data name="numericUpDown1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>610, 7</value>
+    <value>620, 7</value>
   </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 12</value>

--- a/BecquerelMonitor/ROICovellMethodData.cs
+++ b/BecquerelMonitor/ROICovellMethodData.cs
@@ -134,6 +134,14 @@ namespace BecquerelMonitor
             return new ROICovellMethodData(this);
         }
 
+        public override void InitFromDefinition(ROIDefinitionData definition)
+        {
+            base.InitFromDefinition(definition);
+
+            this.LowerLimit = definition.LowerLimit;
+            this.UpperLimit = definition.UpperLimit;
+        }
+
         // Token: 0x040008A5 RID: 2213
         double lowerLimit;
 

--- a/BecquerelMonitor/ROIPrimitiveData.cs
+++ b/BecquerelMonitor/ROIPrimitiveData.cs
@@ -152,6 +152,9 @@ namespace BecquerelMonitor
             return new ROIPrimitiveData(this);
         }
 
+        public virtual void InitFromDefinition(ROIDefinitionData definition)
+        {}
+
         // Token: 0x04000779 RID: 1913
         string primitiveType;
 

--- a/BecquerelMonitor/ROISimpleDifferenceData.cs
+++ b/BecquerelMonitor/ROISimpleDifferenceData.cs
@@ -51,6 +51,14 @@
             return new ROISimpleDifferenceData(this);
         }
 
+        public override void InitFromDefinition(ROIDefinitionData definition)
+        {
+            base.InitFromDefinition(definition);
+
+            this.LowerLimit = definition.LowerLimit;
+            this.UpperLimit = definition.UpperLimit;
+        }
+
         // Token: 0x04000781 RID: 1921
         double lowerLimit;
 

--- a/BecquerelMonitor/Utils/ROIAriphmetics.cs
+++ b/BecquerelMonitor/Utils/ROIAriphmetics.cs
@@ -1,0 +1,78 @@
+﻿using MathNet.Numerics;
+using MathNet.Numerics.Interpolation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BecquerelMonitor.Utils
+{
+    public class ROIAriphmetics
+    {
+        private IInterpolation EffCurve { get; set; }
+        private IInterpolation ErrCurve { get; set; }
+
+        public bool HasValidCurve { get; private set; }
+        public double MaxEnergy { get; private set; }
+        public double MinEnergy { get; private set; }
+
+        public ROIConfigData ROIConfigData { get; private set; }
+
+        public ROIAriphmetics(ROIConfigData config)
+        {
+            this.ROIConfigData = config;
+            this.InitInterpolation();
+        }
+
+        public ROIEfficiencyData CalculateEfficiency(double energy)
+        {
+            if (!this.HasValidCurve || energy < this.MinEnergy || energy > this.MaxEnergy)
+            {
+                return null;
+            }
+            
+            double efficiency = this.EffCurve.Interpolate(energy);
+            double error = this.ErrCurve.Interpolate(energy);
+
+            return new ROIEfficiencyData()
+            {
+                Energy = energy,
+                Efficiency = efficiency,
+                ErrorPercent = error,
+            };
+        }
+
+        private void InitInterpolation()
+        {
+            List<double> effEnergies = new List<double>();
+            List<double> effValues = new List<double>();
+            List<double> effErrors = new List<double>();
+            this.MaxEnergy = double.MinValue;
+            this.MinEnergy = double.MaxValue;
+
+            this.ROIConfigData.ROIEfficiency.ForEach(def =>
+            {
+                if (def.Energy > 0 && def.Efficiency > 0)
+                {
+                    if (def.Energy > this.MaxEnergy) { this.MaxEnergy = def.Energy; }
+                    if (def.Energy < this.MinEnergy) { this.MinEnergy = def.Energy; }
+
+                    effEnergies.Add(def.Energy);
+                    effValues.Add(def.Efficiency);
+                    effErrors.Add(def.ErrorPercent);
+                }
+            });
+
+            if (effEnergies.Count < 2 || this.MaxEnergy <= this.MinEnergy)
+            {
+                this.HasValidCurve = false;
+                return;
+            }
+
+            this.EffCurve = Interpolate.CubicSplineMonotone(effEnergies, effValues);
+            this.ErrCurve = Interpolate.CubicSplineMonotone(effEnergies, effErrors);
+            this.HasValidCurve = true;
+        }
+    }
+}


### PR DESCRIPTION
- add activity concentration values to region selection data
- fix case for activity calculation when net count < Lc (calculate activity based on Lu)
- automatically calculate roi definition coefficient from added isotope and efficiency curve
- adjust selected channel/region tooltip position

![image](https://github.com/Am6er/BecqMoni/assets/8512728/be57f758-69f8-40a1-989f-16e7ad10f55a)
![image](https://github.com/Am6er/BecqMoni/assets/8512728/48244298-efab-4eb6-b79c-123eb3370d32)
![image](https://github.com/Am6er/BecqMoni/assets/8512728/9e5b69f0-2b68-4396-a137-72a3c08ac1cb)
