### PR TITLE
feat (bg-diff): substract background from all spectrums in the list

### DIFF
--- a/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
+++ b/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
@@ -524,7 +524,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public double[] WMA2(int[] spectrum, int numberOfWMADataPoints, int countlimit = 100)
+        public double[] WMA2(double[] spectrum, int numberOfWMADataPoints, int countlimit = 100)
         {
             double[] result = new double[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>
@@ -602,7 +602,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public double[] SMA2(int[] spectrum, int numberOfSMADataPoints, int countlimit = 100)
+        public double[] SMA2(double[] spectrum, int numberOfSMADataPoints, int countlimit = 100)
         {
             double[] result = new double[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>


### PR DESCRIPTION
- store active substracted spectrum as separate field only for calculations (fwhm, for instance)
- to simplify rendering code store substracted specrums as DrawingSpectrum of any spectrum in the list
- calculate view boundaries (fit/min/max etc) based on drawing spectrums
- apply smoothing to drawing spectrums