### PR TITLE
feat (import): add option to set empty configuration for imported spectrums

### DIFF
--- a/BecquerelMonitor/GlobalConfigForm.Designer.cs
+++ b/BecquerelMonitor/GlobalConfigForm.Designer.cs
@@ -225,6 +225,8 @@
             this.autoSaveDefaultPolicyCheckBox = new System.Windows.Forms.CheckBox();
 			this.confidenceLevelcomboBox = new System.Windows.Forms.ComboBox();
 			this.confidenceLevelLabel = new System.Windows.Forms.Label();
+			this.miscSettingsGroupBox = new global::System.Windows.Forms.GroupBox();
+			this.importSpectrumWithEmptyConfigCheckBox = new global::System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
 			this.tabPage1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -246,6 +248,7 @@
 			this.tabPage2.SuspendLayout();
 			this.groupBox6.SuspendLayout();
 			this.groupBox5.SuspendLayout();
+			this.miscSettingsGroupBox.SuspendLayout();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown5).BeginInit();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown4).BeginInit();
 			base.SuspendLayout();
@@ -1049,6 +1052,7 @@
 			this.tabPage2.BackColor = global::System.Drawing.SystemColors.Control;
 			this.tabPage2.Controls.Add(this.groupBox6);
 			this.tabPage2.Controls.Add(this.groupBox5);
+			this.tabPage2.Controls.Add(this.miscSettingsGroupBox);
 			this.tabPage2.Name = "tabPage2";
 			resources.ApplyResources(this.groupBox6, "groupBox6");
 			this.groupBox6.Controls.Add(this.checkBox1);
@@ -1059,6 +1063,21 @@
             this.groupBox6.Controls.Add(this.autoSaveDefaultPolicyCheckBox);
             this.groupBox6.Name = "groupBox6";
 			this.groupBox6.TabStop = false;
+
+            // ------------ misc settings -----------------
+
+			resources.ApplyResources(this.importSpectrumWithEmptyConfigCheckBox, "importSpectrumWithEmptyConfigCheckBox");
+			this.importSpectrumWithEmptyConfigCheckBox.Name = "importSpectrumWithEmptyConfigCheckBox";
+			this.importSpectrumWithEmptyConfigCheckBox.Location = new System.Drawing.Point(21, 17);
+			this.importSpectrumWithEmptyConfigCheckBox.Size = new System.Drawing.Size(500, 16);
+
+            resources.ApplyResources(this.miscSettingsGroupBox, "miscSettingsGroupBox");
+            this.miscSettingsGroupBox.Name = "miscSettingsGroupBox";
+			this.miscSettingsGroupBox.Location = new System.Drawing.Point(6, 400);
+			this.miscSettingsGroupBox.Size = new System.Drawing.Size(664, 150);
+			this.miscSettingsGroupBox.Controls.Add(this.importSpectrumWithEmptyConfigCheckBox);
+            // ------------ end misc settings --------------
+
 			resources.ApplyResources(this.groupBox5, "groupBox5");
 			this.groupBox5.Controls.Add(this.checkBox2);
 			this.groupBox5.Controls.Add(this.comboBox14);
@@ -1193,6 +1212,8 @@
 			this.groupBox6.PerformLayout();
 			this.groupBox5.ResumeLayout(false);
 			this.groupBox5.PerformLayout();
+			this.miscSettingsGroupBox.ResumeLayout();
+			this.miscSettingsGroupBox.PerformLayout();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown5).EndInit();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown4).EndInit();
 			base.ResumeLayout(false);
@@ -1802,5 +1823,7 @@
 		global::System.Windows.Forms.CheckBox autoSaveDefaultPolicyCheckBox;
         global::System.Windows.Forms.ComboBox confidenceLevelcomboBox;
         global::System.Windows.Forms.Label confidenceLevelLabel;
+        global::System.Windows.Forms.GroupBox miscSettingsGroupBox;
+        global::System.Windows.Forms.CheckBox importSpectrumWithEmptyConfigCheckBox;
     }
 }

--- a/BecquerelMonitor/GlobalConfigForm.cs
+++ b/BecquerelMonitor/GlobalConfigForm.cs
@@ -85,6 +85,7 @@ namespace BecquerelMonitor
             this.numericUpDown14.Value = (decimal)globalConfig.ChartViewConfig.HorizontalScale;
             this.comboBox11.SelectedIndex = (int)globalConfig.ChartViewConfig.MagnificationReference;
             this.autoSaveDefaultPolicyCheckBox.Checked = globalConfig.AutosaveDefaultPolicy;
+            this.importSpectrumWithEmptyConfigCheckBox.Checked = globalConfig.ImportSpectrumWithEmptyConfig;
             this.confidenceLevelcomboBox.SelectedIndex = ConfidenceLevel.GetSingleSideLevelIndex(globalConfig.ChartViewConfig.ConfidenceLevel);
             EasyControlConfig easyControlConfig = globalConfig.EasyControlConfig;
             bool flag = false;
@@ -246,7 +247,9 @@ namespace BecquerelMonitor
             globalConfig.DoSaveRawPulseData = this.checkBox1.Checked;
             globalConfig.AutosavePeriod = (int)this.numericUpDown10.Value;
             globalConfig.AutosaveDefaultPolicy = this.autoSaveDefaultPolicyCheckBox.Checked;
+            globalConfig.ImportSpectrumWithEmptyConfig = this.importSpectrumWithEmptyConfigCheckBox.Checked;
             globalConfig.ChartViewConfig.HorizontalScale = (double)this.numericUpDown14.Value;
+
         }
 
         // Token: 0x06000AC7 RID: 2759 RVA: 0x00041060 File Offset: 0x0003F260

--- a/BecquerelMonitor/GlobalConfigForm.resx
+++ b/BecquerelMonitor/GlobalConfigForm.resx
@@ -5778,4 +5778,10 @@
   <data name="&gt;&gt;confidenceLevelcomboBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="miscSettingsGroupBox.Text" xml:space="preserve">
+    <value>Misc</value>
+  </data>
+  <data name="importSpectrumWithEmptyConfigCheckBox.Text" xml:space="preserve">
+    <value>Set empty configuration for imported spectrums</value>
+  </data>
 </root>

--- a/BecquerelMonitor/GlobalConfigForm.ru.resx
+++ b/BecquerelMonitor/GlobalConfigForm.ru.resx
@@ -2952,4 +2952,10 @@
   <data name="confidenceLevelLabel.Text" xml:space="preserve">
     <value>Стат. лимиты, доверит. интервал:</value>
   </data>
+  <data name="miscSettingsGroupBox.Text" xml:space="preserve">
+    <value>Прочее</value>
+  </data>
+  <data name="importSpectrumWithEmptyConfigCheckBox.Text" xml:space="preserve">
+    <value>Устанавливать пустую конфигурацию импортируемым спектрам</value>
+  </data>
 </root>

--- a/BecquerelMonitor/GlobalConfigInfo.cs
+++ b/BecquerelMonitor/GlobalConfigInfo.cs
@@ -375,6 +375,18 @@ namespace BecquerelMonitor
                 this.autosavedefaultpolicy = value;
             }
         }
+        
+        public bool ImportSpectrumWithEmptyConfig
+        {
+            get
+            {
+                return this.importSpectrumWithEmptyConfig;
+            }
+            set
+            {
+                this.importSpectrumWithEmptyConfig = value;
+            }
+        }
 
         // Token: 0x040008AF RID: 2223
         int mainFormTop = 100;
@@ -431,6 +443,8 @@ namespace BecquerelMonitor
         int autosaveperiod = 15;
 
         bool autosavedefaultpolicy = false;
+
+        bool importSpectrumWithEmptyConfig = false;
 
         // Token: 0x040008BD RID: 2237
         ResultTranslation resultTranslation = ResultTranslation.Becquerels;


### PR DESCRIPTION
- affects imports: atomspectra, n42, csv
- in case global option is set, imported spectrum clears any existing calibration, background, device and ROI
- do the same config reset in case there is a channel mismatch for atom spectra import
- when option is set import all the channels from csv (not only what fits current/default device)