### PR TITLE
feat (nuclides): add initial support of nuclide sets

### DIFF
--- a/BecquerelMonitor/BecquerelMonitor.csproj
+++ b/BecquerelMonitor/BecquerelMonitor.csproj
@@ -422,6 +422,7 @@
     </Compile>
     <Compile Include="NucBase\NucBaseFramework.cs" />
     <Compile Include="NucBase\Nuclide.cs" />
+    <Compile Include="NuclideSet.cs" />
     <Compile Include="NuclideDefinition.cs" />
     <Compile Include="NuclideDefinitionFile.cs" />
     <Compile Include="NuclideDefinitionForm.cs">
@@ -431,6 +432,12 @@
       <DependentUpon>NuclideDefinitionForm.cs</DependentUpon>
     </Compile>
     <Compile Include="NuclideDefinitionManager.cs" />
+    <Compile Include="NuclideSetForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="NuclideSetForm.Designer.cs">
+      <DependentUpon>NuclideSetForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="OutofChannelException.cs" />
     <Compile Include="Package.cs" />
     <Compile Include="Peak.cs" />
@@ -924,9 +931,11 @@
     </EmbeddedResource>
     <EmbeddedResource Include="DCPeakDetectionView.resx">
       <DependentUpon>DCPeakDetectionView.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="DCPeakDetectionView.ru.resx">
       <DependentUpon>DCPeakDetectionView.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="DCPulseView.resx">
       <DependentUpon>DCPulseView.cs</DependentUpon>
@@ -1020,6 +1029,13 @@
     </EmbeddedResource>
     <EmbeddedResource Include="NuclideDefinitionForm.ru.resx">
       <DependentUpon>NuclideDefinitionForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="NuclideSetForm.resx">
+      <DependentUpon>NuclideSetForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="NuclideSetForm.ru.resx">
+      <DependentUpon>NuclideSetForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/BecquerelMonitor/DCPeakDetectionView.Designer.cs
+++ b/BecquerelMonitor/DCPeakDetectionView.Designer.cs
@@ -44,6 +44,8 @@ namespace BecquerelMonitor
 			this.numericUpDown3 = new global::System.Windows.Forms.NumericUpDown();
 			this.button1 = new global::System.Windows.Forms.Button();
 			this.label4 = new global::System.Windows.Forms.Label();
+			this.comboBoxNuclSet = new System.Windows.Forms.ComboBox();
+			this.labelSetName = new System.Windows.Forms.Label();
 			((global::System.ComponentModel.ISupportInitialize)this.table1).BeginInit();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown1).BeginInit();
 			((global::System.ComponentModel.ISupportInitialize)this.numericUpDown2).BeginInit();
@@ -164,6 +166,29 @@ namespace BecquerelMonitor
 			this.button1.Click += new global::System.EventHandler(this.button1_Click);
 			resources.ApplyResources(this.label4, "label4");
 			this.label4.Name = "label4";
+
+			// 
+			// comboBoxNuclSet
+			// 
+			this.comboBoxNuclSetAllNuclidesText = resources.GetString("ComboBoxNuclSetAllNuclides");
+			this.comboBoxNuclSet.FormattingEnabled = true;
+			this.comboBoxNuclSet.Location = new System.Drawing.Point(62, 33);
+			this.comboBoxNuclSet.Name = "comboBoxNuclSet";
+			this.comboBoxNuclSet.Size = new System.Drawing.Size(162, 21);
+			this.comboBoxNuclSet.TabIndex = 10;
+			this.comboBoxNuclSet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxNuclSet.SelectedIndexChanged += new System.EventHandler(this.comboBoxNuclSet_SelectedIndexChanged);
+
+			//	
+			// labelSetName
+			// 
+			resources.ApplyResources(this.labelSetName, "labelSetName");
+			this.labelSetName.Location = new System.Drawing.Point(7, 37);
+			this.labelSetName.Name = "labelSetName";
+			this.labelSetName.Size = new System.Drawing.Size(46, 13);
+			this.labelSetName.TabIndex = 11;
+
+
 			resources.ApplyResources(this, "$this");
 			base.Controls.Add(this.label4);
 			base.Controls.Add(this.button1);
@@ -174,6 +199,8 @@ namespace BecquerelMonitor
 			base.Controls.Add(this.numericUpDown2);
 			base.Controls.Add(this.numericUpDown1);
 			base.Controls.Add(this.table1);
+			this.Controls.Add(this.labelSetName);
+			this.Controls.Add(this.comboBoxNuclSet);
 			base.HideOnClose = true;
 			base.Name = "DCPeakDetectionView";
 			((global::System.ComponentModel.ISupportInitialize)this.table1).EndInit();
@@ -242,5 +269,9 @@ namespace BecquerelMonitor
 		global::System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
 
 		global::System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-	}
+
+		global::System.Windows.Forms.ComboBox comboBoxNuclSet;
+
+		global::System.Windows.Forms.Label labelSetName;
+    }
 }

--- a/BecquerelMonitor/DCPeakDetectionView.cs
+++ b/BecquerelMonitor/DCPeakDetectionView.cs
@@ -14,6 +14,8 @@ namespace BecquerelMonitor
         {
             this.mainForm = mainForm;
             this.InitializeComponent();
+
+            this.RefreshNuclideSets();
         }
 
         // Token: 0x0600043E RID: 1086 RVA: 0x0001423C File Offset: 0x0001243C
@@ -71,6 +73,11 @@ namespace BecquerelMonitor
         public void UpdatePeakDetectionResult()
         {
             DocEnergySpectrum activeDocument = this.mainForm.ActiveDocument;
+            if (activeDocument == null)
+            {
+                return;
+            }
+
             FWHMPeakDetectionMethodConfig peakConfig = (FWHMPeakDetectionMethodConfig) activeDocument.ActiveResultData.PeakDetectionMethodConfig;
             if (!peakConfig.Enabled)
             {
@@ -79,7 +86,7 @@ namespace BecquerelMonitor
             ResultData activeResultData = activeDocument.ActiveResultData;
             PeakDetector peakDetector = new PeakDetector();
             List<Peak> list = null;
-            list = peakDetector.DetectPeak(activeResultData, activeDocument.EnergySpectrumView.BackgroundMode, activeDocument.EnergySpectrumView.SmoothingMethod);
+            list = peakDetector.DetectPeak(activeResultData, activeDocument.EnergySpectrumView.BackgroundMode, activeDocument.EnergySpectrumView.SmoothingMethod, this.selectedNuclideSet);
 
             this.tableModel1.Rows.Clear();
             foreach (Peak peak in list)
@@ -104,6 +111,24 @@ namespace BecquerelMonitor
             }
             activeDocument.RefreshView();
             //this.table1.AutoResizeColumnWidths();
+        }
+
+        public void RefreshNuclideSets()
+        {
+            this.comboBoxNuclSet.Items.Clear();
+            this.comboBoxNuclSet.Items.Add(comboBoxNuclSetAllNuclidesText);
+            foreach (NuclideSet set in this.nuclideManager.NuclideSets)
+            {
+                this.comboBoxNuclSet.Items.Add(set.Name);
+            }
+            if (this.selectedNuclideSet != null)
+            {
+                this.comboBoxNuclSet.SelectedIndex = this.nuclideManager.NuclideSets.IndexOf(this.selectedNuclideSet) + 1;
+            }
+            else
+            {
+                this.comboBoxNuclSet.SelectedIndex = 0;
+            }
         }
 
         // Token: 0x06000440 RID: 1088 RVA: 0x00014468 File Offset: 0x00012668
@@ -207,6 +232,20 @@ namespace BecquerelMonitor
             this.mainForm.ShowNuclideDefinitionForm();
         }
 
+        private void comboBoxNuclSet_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (this.comboBoxNuclSet.SelectedIndex > 0)
+            {
+                this.selectedNuclideSet = this.nuclideManager.NuclideSets[this.comboBoxNuclSet.SelectedIndex - 1];
+            }
+            else
+            {
+                this.selectedNuclideSet = null;
+            }
+
+            this.UpdatePeakDetectionResult();
+        }
+
         // Token: 0x040001B3 RID: 435
         MainForm mainForm;
 
@@ -216,6 +255,12 @@ namespace BecquerelMonitor
         // Token: 0x040001B5 RID: 437
         GlobalConfigManager globalConfigManager = GlobalConfigManager.GetInstance();
 
+        NuclideDefinitionManager nuclideManager = NuclideDefinitionManager.GetInstance();
+
         bool FormLoading = false;
+
+        string comboBoxNuclSetAllNuclidesText;
+
+        private NuclideSet selectedNuclideSet = null;
     }
 }

--- a/BecquerelMonitor/DCPeakDetectionView.resx
+++ b/BecquerelMonitor/DCPeakDetectionView.resx
@@ -329,7 +329,7 @@
     <value>6</value>
   </data>
   <data name="table1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 61</value>
+    <value>0, 75</value>
   </data>
   <data name="&gt;&gt;tableModel1.Name" xml:space="preserve">
     <value>tableModel1</value>
@@ -497,7 +497,7 @@
     <value>90</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 43</value>
+    <value>7, 60</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -507,5 +507,11 @@
   </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 12</value>
+  </data>
+  <data name="labelSetName.Text" xml:space="preserve">
+    <value>Use set:</value>
+  </data>
+  <data name="ComboBoxNuclSetAllNuclides" xml:space="preserve">
+    <value>--- All Nuclides ---</value>
   </data>
 </root>

--- a/BecquerelMonitor/DCPeakDetectionView.ru.resx
+++ b/BecquerelMonitor/DCPeakDetectionView.ru.resx
@@ -361,4 +361,10 @@
   <data name="textColumn6.Text" xml:space="preserve">
     <value>FWHM</value>
   </data>
+  <data name="labelSetName.Text" xml:space="preserve">
+    <value>Набор:</value>
+  </data>
+  <data name="ComboBoxNuclSetAllNuclides" xml:space="preserve">
+    <value>--- Все изотопы ---</value>
+  </data>
 </root>

--- a/BecquerelMonitor/MainForm.Designer.cs
+++ b/BecquerelMonitor/MainForm.Designer.cs
@@ -104,7 +104,8 @@ namespace BecquerelMonitor
 			this.ツ\u30FCルTToolStripMenuItem1 = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.デバイス構成の編集DToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.rOI定義RToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
-			this.核種定義の編集NToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
+			this.NuclideDefinitionToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
+			this.NuclideSetToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.OpenConfigNToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.NucDB = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator5 = new global::System.Windows.Forms.ToolStripSeparator();
@@ -391,7 +392,8 @@ namespace BecquerelMonitor
 			{
 				this.デバイス構成の編集DToolStripMenuItem,
 				this.rOI定義RToolStripMenuItem,
-				this.核種定義の編集NToolStripMenuItem,
+				this.NuclideDefinitionToolStripMenuItem,
+				this.NuclideSetToolStripMenuItem,
 				this.NucDB,
 				this.OpenConfigNToolStripMenuItem,
 				this.toolStripSeparator5,
@@ -404,9 +406,12 @@ namespace BecquerelMonitor
 			resources.ApplyResources(this.rOI定義RToolStripMenuItem, "rOI定義RToolStripMenuItem");
 			this.rOI定義RToolStripMenuItem.Name = "rOI定義RToolStripMenuItem";
 			this.rOI定義RToolStripMenuItem.Click += new global::System.EventHandler(this.rOI定義RToolStripMenuItem_Click);
-			resources.ApplyResources(this.核種定義の編集NToolStripMenuItem, "核種定義の編集NToolStripMenuItem");
-			this.核種定義の編集NToolStripMenuItem.Name = "核種定義の編集NToolStripMenuItem";
-			this.核種定義の編集NToolStripMenuItem.Click += new global::System.EventHandler(this.核種定義の編集NToolStripMenuItem_Click);
+			resources.ApplyResources(this.NuclideDefinitionToolStripMenuItem, "NuclideDefinitionToolStripMenuItem");
+			this.NuclideDefinitionToolStripMenuItem.Name = "NuclideDefinitionToolStripMenuItem";
+			this.NuclideDefinitionToolStripMenuItem.Click += new global::System.EventHandler(this.NuclideDefinitionToolStripMenuItem_Click);
+			resources.ApplyResources(this.NuclideSetToolStripMenuItem, "NuclideSetToolStripMenuItem");
+			this.NuclideSetToolStripMenuItem.Name = "NuclideSetToolStripMenuItem";
+			this.NuclideSetToolStripMenuItem.Click += new global::System.EventHandler(this.NuclideSetToolStripMenuItem_Click);
 			resources.ApplyResources(this.OpenConfigNToolStripMenuItem, "OpenConfigNToolStripMenuItem");
 			this.OpenConfigNToolStripMenuItem.Name = "OpenConfigNToolStripMenuItem";
 			this.OpenConfigNToolStripMenuItem.Click += new global::System.EventHandler(this.OpenConfigNToolStripMenuItem_Click);
@@ -701,8 +706,10 @@ namespace BecquerelMonitor
 
         global::System.Windows.Forms.ToolStripMenuItem AutoSaveStripMenuItem;
 
-        // Token: 0x040005B4 RID: 1460
-        global::System.Windows.Forms.ToolStripMenuItem 核種定義の編集NToolStripMenuItem;
+		// Token: 0x040005B4 RID: 1460
+		global::System.Windows.Forms.ToolStripMenuItem NuclideDefinitionToolStripMenuItem;
+
+		global::System.Windows.Forms.ToolStripMenuItem NuclideSetToolStripMenuItem;
 
 		global::System.Windows.Forms.ToolStripMenuItem OpenConfigNToolStripMenuItem;
 

--- a/BecquerelMonitor/MainForm.cs
+++ b/BecquerelMonitor/MainForm.cs
@@ -1141,9 +1141,14 @@ namespace BecquerelMonitor
         }
 
         // Token: 0x06000A71 RID: 2673 RVA: 0x0003E230 File Offset: 0x0003C430
-        void 核種定義の編集NToolStripMenuItem_Click(object sender, EventArgs e)
+        void NuclideDefinitionToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.ShowNuclideDefinitionForm();
+        }
+
+        void NuclideSetToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.ShowNuclideSetForm();
         }
 
         void OpenConfigNToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1189,6 +1194,12 @@ namespace BecquerelMonitor
             this.nuclideDefinitionForm.Show();
             this.nuclideDefinitionForm.Activate();
             return this.nuclideDefinitionForm;
+        }
+
+        public void ShowNuclideSetForm()
+        {
+            NuclideSetForm form = new NuclideSetForm(this);
+            form.ShowDialog();
         }
 
         // Token: 0x06000A73 RID: 2675 RVA: 0x0003E2F4 File Offset: 0x0003C4F4
@@ -2086,6 +2097,14 @@ namespace BecquerelMonitor
             catch (Exception ex)
             {
                 MessageBox.Show(string.Format(Resources.ERRFileSaveFailure, fileName, ex.Message));
+            }
+        }
+
+        public void RefresNuclideSetList()
+        {
+            if (this.dcPeakDetectionView != null)
+            {
+                this.dcPeakDetectionView.RefreshNuclideSets();
             }
         }
 

--- a/BecquerelMonitor/MainForm.resx
+++ b/BecquerelMonitor/MainForm.resx
@@ -755,23 +755,23 @@
   <data name="dockPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 26</value>
   </data>
-  <data name="核種定義の編集NToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="NuclideDefinitionToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>240, 22</value>
   </data>
-  <data name="核種定義の編集NToolStripMenuItem.Text" xml:space="preserve">
+  <data name="NuclideDefinitionToolStripMenuItem.Text" xml:space="preserve">
     <value>Edit &amp;Nuclide Definitions...</value>
   </data>
   <data name="&gt;&gt;削除DToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;核種定義の編集NToolStripMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;NuclideDefinitionToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;削除DToolStripMenuItem.Name" xml:space="preserve">
     <value>削除DToolStripMenuItem</value>
   </data>
-  <data name="&gt;&gt;核種定義の編集NToolStripMenuItem.Name" xml:space="preserve">
-    <value>核種定義の編集NToolStripMenuItem</value>
+  <data name="&gt;&gt;NuclideDefinitionToolStripMenuItem.Name" xml:space="preserve">
+    <value>NuclideDefinitionToolStripMenuItem</value>
   </data>
   <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 6</value>
@@ -1141,5 +1141,8 @@
   </data>
   <data name="&gt;&gt;exportBgToolStripMenuItem.Name" xml:space="preserve">
     <value>exportBgToolStripMenuItem</value>
+  </data>
+  <data name="NuclideSetToolStripMenuItem.Text" xml:space="preserve">
+    <value>Edit Nuclide Sets...</value>
   </data>
 </root>

--- a/BecquerelMonitor/MainForm.ru.resx
+++ b/BecquerelMonitor/MainForm.ru.resx
@@ -543,10 +543,10 @@
   <data name="&gt;&gt;既存ファイルから追加FToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;核種定義の編集NToolStripMenuItem.Name" xml:space="preserve">
-    <value>核種定義の編集NToolStripMenuItem</value>
+  <data name="&gt;&gt;NuclideDefinitionToolStripMenuItem.Name" xml:space="preserve">
+    <value>NuclideDefinitionToolStripMenuItem</value>
   </data>
-  <data name="&gt;&gt;核種定義の編集NToolStripMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;NuclideDefinitionToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;測定停止TToolStripMenuItem.Name" xml:space="preserve">
@@ -741,7 +741,7 @@
   <data name="既存ファイルから追加FToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Импорт из файла</value>
   </data>
-  <data name="核種定義の編集NToolStripMenuItem.Text" xml:space="preserve">
+  <data name="NuclideDefinitionToolStripMenuItem.Text" xml:space="preserve">
     <value>Редактировать библиотеку изотопов...</value>
   </data>
   <data name="測定停止TToolStripMenuItem.Text" xml:space="preserve">
@@ -779,5 +779,8 @@
   </data>
   <data name="exportBgToolStripMenuItem.Text" xml:space="preserve">
     <value>Экспортировать спектр фона в файл</value>
+  </data>
+  <data name="NuclideSetToolStripMenuItem.Text" xml:space="preserve">
+    <value>Редактировать наборы изотопов...</value>
   </data>
 </root>

--- a/BecquerelMonitor/NuclideDefinition.cs
+++ b/BecquerelMonitor/NuclideDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml.Serialization;
 using System.Drawing;
+using System.Collections.Generic;
 
 namespace BecquerelMonitor
 {
@@ -132,6 +133,18 @@ namespace BecquerelMonitor
             }
         }
 
+        public HashSet<Guid> Sets
+        {
+            get
+            {
+                return this.sets;
+            }
+            set
+            {
+                this.sets = value;
+            }
+        }
+
         // Token: 0x040009B1 RID: 2481
         string name = "";
 
@@ -152,5 +165,7 @@ namespace BecquerelMonitor
         double intensity = 0;
 
         SerializableColor nuclideColor = Color.Gray;
+
+        HashSet<Guid> sets = new HashSet<Guid>();
     }
 }

--- a/BecquerelMonitor/NuclideDefinitionFile.cs
+++ b/BecquerelMonitor/NuclideDefinitionFile.cs
@@ -22,7 +22,21 @@ namespace BecquerelMonitor
             }
         }
 
+        [XmlArrayItem("NuclideSet", typeof(NuclideSet))]
+        public List<NuclideSet> NuclideSets
+        {
+            get
+            {
+                return this.nuclideSets;
+            }
+            set
+            {
+                this.nuclideSets = value;
+            }
+        }
+
         // Token: 0x040009B0 RID: 2480
         List<NuclideDefinition> nuclideDefinitions = new List<NuclideDefinition>();
+        List<NuclideSet> nuclideSets = new List<NuclideSet>();
     }
 }

--- a/BecquerelMonitor/NuclideDefinitionManager.cs
+++ b/BecquerelMonitor/NuclideDefinitionManager.cs
@@ -40,6 +40,18 @@ namespace BecquerelMonitor
             }
         }
 
+        public List<NuclideSet> NuclideSets
+        {
+            get
+            {
+                return this.nuclideDefinitionFile.NuclideSets;
+            }
+            set
+            {
+                this.nuclideDefinitionFile.NuclideSets = value;
+            }
+        }
+
         // Token: 0x06000932 RID: 2354 RVA: 0x00035750 File Offset: 0x00033950
         public static NuclideDefinitionManager GetInstance()
         {
@@ -57,9 +69,9 @@ namespace BecquerelMonitor
         }
 
         // Token: 0x06000934 RID: 2356 RVA: 0x000357C4 File Offset: 0x000339C4
-        public bool LoadDefinitionFile()
+        public bool LoadDefinitionFile(bool forceReload = false)
         {
-            if (this.isLoaded)
+            if (this.isLoaded && !forceReload)
             {
                 return true;
             }

--- a/BecquerelMonitor/NuclideSet.cs
+++ b/BecquerelMonitor/NuclideSet.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace BecquerelMonitor
+{
+    public class NuclideSet
+    {
+        public Guid Id
+        {
+            get
+            {
+                return this.id;
+            }
+            set
+            {
+                this.id = value;
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return this.name;
+            }
+            set
+            {
+                this.name = value;
+            }
+        }
+
+        public bool HideUnknownPeaks
+        {
+            get
+            {
+                return this.hideUnknownPeaks;
+            }
+            set
+            {
+                this.hideUnknownPeaks = value;
+            }
+        }
+
+        Guid id = Guid.Empty;
+        string name = "";
+        bool hideUnknownPeaks = false;
+    }
+}

--- a/BecquerelMonitor/NuclideSetForm.Designer.cs
+++ b/BecquerelMonitor/NuclideSetForm.Designer.cs
@@ -1,0 +1,229 @@
+﻿using BecquerelMonitor.Properties;
+
+namespace BecquerelMonitor
+{
+    partial class NuclideSetForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NuclideSetForm));
+            XPTable.Models.DataSourceColumnBinder dataSourceColumnBinder1 = new XPTable.Models.DataSourceColumnBinder();
+            XPTable.Renderers.DragDropRenderer dragDropRenderer1 = new XPTable.Renderers.DragDropRenderer();
+            XPTable.Models.DataSourceColumnBinder dataSourceColumnBinder2 = new XPTable.Models.DataSourceColumnBinder();
+            XPTable.Renderers.DragDropRenderer dragDropRenderer2 = new XPTable.Renderers.DragDropRenderer();
+            this.buttonClose = new System.Windows.Forms.Button();
+            this.buttonSave = new System.Windows.Forms.Button();
+            this.groupBoxEdit = new System.Windows.Forms.GroupBox();
+            this.tableNuclides = new XPTable.Models.Table();
+            this.columnModelNuclides = new XPTable.Models.ColumnModel();
+            this.columnNuclideIncluded = new XPTable.Models.CheckBoxColumn();
+            this.columnNuclideName = new XPTable.Models.TextColumn();
+            this.columnNuclideEnergy = new XPTable.Models.TextColumn();
+            this.tableModelNuclides = new XPTable.Models.TableModel();
+            this.buttonDeleteSet = new System.Windows.Forms.Button();
+            this.labelNuclides = new System.Windows.Forms.Label();
+            this.buttonAddSet = new System.Windows.Forms.Button();
+            this.labelSets = new System.Windows.Forms.Label();
+            this.tableSets = new XPTable.Models.Table();
+            this.columnModelSets = new XPTable.Models.ColumnModel();
+            this.columnSetName = new XPTable.Models.TextColumn();
+            this.columnSetHideUnknown = new XPTable.Models.CheckBoxColumn();
+            this.tableModelSets = new XPTable.Models.TableModel();
+            this.groupBoxEdit.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tableNuclides)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tableSets)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // buttonClose
+            // 
+            resources.ApplyResources(this.buttonClose, "buttonClose");
+            this.buttonClose.Name = "buttonClose";
+            this.buttonClose.UseVisualStyleBackColor = true;
+            this.buttonClose.Click += new System.EventHandler(this.buttonClose_Click);
+            // 
+            // buttonSave
+            // 
+            resources.ApplyResources(this.buttonSave, "buttonSave");
+            this.buttonSave.Name = "buttonSave";
+            this.buttonSave.UseVisualStyleBackColor = true;
+            this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
+            // 
+            // groupBoxEdit
+            // 
+            resources.ApplyResources(this.groupBoxEdit, "groupBoxEdit");
+            this.groupBoxEdit.Controls.Add(this.tableNuclides);
+            this.groupBoxEdit.Controls.Add(this.buttonDeleteSet);
+            this.groupBoxEdit.Controls.Add(this.labelNuclides);
+            this.groupBoxEdit.Controls.Add(this.buttonAddSet);
+            this.groupBoxEdit.Controls.Add(this.labelSets);
+            this.groupBoxEdit.Controls.Add(this.tableSets);
+            this.groupBoxEdit.Name = "groupBoxEdit";
+            this.groupBoxEdit.TabStop = false;
+            // 
+            // tableNuclides
+            // 
+            resources.ApplyResources(this.tableNuclides, "tableNuclides");
+            this.tableNuclides.BorderColor = System.Drawing.Color.Black;
+            this.tableNuclides.ColumnModel = this.columnModelNuclides;
+            this.tableNuclides.DataMember = null;
+            this.tableNuclides.DataSourceColumnBinder = dataSourceColumnBinder1;
+            dragDropRenderer1.ForeColor = System.Drawing.Color.Red;
+            this.tableNuclides.DragDropRenderer = dragDropRenderer1;
+            this.tableNuclides.GridLinesContrainedToData = false;
+            this.tableNuclides.Name = "tableNuclides";
+            this.tableNuclides.TableModel = this.tableModelNuclides;
+            this.tableNuclides.UnfocusedBorderColor = System.Drawing.Color.Black;
+            this.tableNuclides.CellClick += new XPTable.Events.CellMouseEventHandler(this.tableNuclides_CellClick);
+            this.tableNuclides.HeaderClick += new XPTable.Events.HeaderMouseEventHandler(this.tableNuclides_HeaderClick);
+            // 
+            // columnModelNuclides
+            // 
+            this.columnModelNuclides.Columns.AddRange(new XPTable.Models.Column[] {
+            this.columnNuclideIncluded,
+            this.columnNuclideName,
+            this.columnNuclideEnergy});
+            // 
+            // columnNuclideIncluded
+            // 
+            resources.ApplyResources(this.columnNuclideIncluded, "columnNuclideIncluded");
+            this.columnNuclideIncluded.IsTextTrimmed = false;
+            this.columnNuclideIncluded.Resizable = false;
+            this.columnNuclideIncluded.Selectable = false;
+            this.columnNuclideIncluded.Sortable = false;
+            // 
+            // columnNuclideName
+            // 
+            resources.ApplyResources(this.columnNuclideName, "columnNuclideName");
+            this.columnNuclideName.Editable = false;
+            this.columnNuclideName.IsTextTrimmed = false;
+            this.columnNuclideName.Selectable = false;
+            this.columnNuclideName.Sortable = false;
+            // 
+            // columnNuclideEnergy
+            // 
+            resources.ApplyResources(this.columnNuclideEnergy, "columnNuclideEnergy");
+            this.columnNuclideEnergy.Editable = false;
+            this.columnNuclideEnergy.IsTextTrimmed = false;
+            this.columnNuclideEnergy.Selectable = false;
+            this.columnNuclideEnergy.Sortable = false;
+            // 
+            // buttonDeleteSet
+            // 
+            resources.ApplyResources(this.buttonDeleteSet, "buttonDeleteSet");
+            this.buttonDeleteSet.Name = "buttonDeleteSet";
+            this.buttonDeleteSet.UseVisualStyleBackColor = true;
+            this.buttonDeleteSet.Click += new System.EventHandler(this.buttonDeleteSet_Click);
+            // 
+            // labelNuclides
+            // 
+            resources.ApplyResources(this.labelNuclides, "labelNuclides");
+            this.labelNuclides.Name = "labelNuclides";
+            // 
+            // buttonAddSet
+            // 
+            resources.ApplyResources(this.buttonAddSet, "buttonAddSet");
+            this.buttonAddSet.Name = "buttonAddSet";
+            this.buttonAddSet.UseVisualStyleBackColor = true;
+            this.buttonAddSet.Click += new System.EventHandler(this.buttonAddSet_Click);
+            // 
+            // labelSets
+            // 
+            resources.ApplyResources(this.labelSets, "labelSets");
+            this.labelSets.Name = "labelSets";
+            // 
+            // tableSets
+            // 
+            resources.ApplyResources(this.tableSets, "tableSets");
+            this.tableSets.BorderColor = System.Drawing.Color.Black;
+            this.tableSets.ColumnModel = this.columnModelSets;
+            this.tableSets.DataMember = null;
+            this.tableSets.DataSourceColumnBinder = dataSourceColumnBinder2;
+            dragDropRenderer2.ForeColor = System.Drawing.Color.Red;
+            this.tableSets.DragDropRenderer = dragDropRenderer2;
+            this.tableSets.GridLinesContrainedToData = false;
+            this.tableSets.Name = "tableSets";
+            this.tableSets.TableModel = this.tableModelSets;
+            this.tableSets.UnfocusedBorderColor = System.Drawing.Color.Black;
+            this.tableSets.CellCheckChanged += new XPTable.Events.CellCheckBoxEventHandler(this.tableSets_CellCheckChanged);
+            this.tableSets.EditingStopped += new XPTable.Events.CellEditEventHandler(this.tableSets_EditingStopped);
+            this.tableSets.SelectionChanged += new XPTable.Events.SelectionEventHandler(this.tableSets_SelectionChanged);
+            // 
+            // columnModelSets
+            // 
+            this.columnModelSets.Columns.AddRange(new XPTable.Models.Column[] {
+            this.columnSetName,
+            this.columnSetHideUnknown});
+            // 
+            // columnSetName
+            // 
+            resources.ApplyResources(this.columnSetName, "columnSetName");
+            this.columnSetName.IsTextTrimmed = false;
+            this.columnSetName.Sortable = false;
+            // 
+            // columnSetHideUnknown
+            // 
+            resources.ApplyResources(this.columnSetHideUnknown, "columnSetHideUnknown");
+            this.columnSetHideUnknown.IsTextTrimmed = false;
+            // 
+            // NuclideSetForm
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBoxEdit);
+            this.Controls.Add(this.buttonSave);
+            this.Controls.Add(this.buttonClose);
+            this.Name = "NuclideSetForm";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NuclideSetForm_FormClosing);
+            this.groupBoxEdit.ResumeLayout(false);
+            this.groupBoxEdit.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tableNuclides)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tableSets)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+        private System.Windows.Forms.Button buttonClose;
+        private System.Windows.Forms.Button buttonSave;
+        private System.Windows.Forms.GroupBox groupBoxEdit;
+        private XPTable.Models.Table tableNuclides;
+        private System.Windows.Forms.Button buttonDeleteSet;
+        private System.Windows.Forms.Label labelNuclides;
+        private System.Windows.Forms.Button buttonAddSet;
+        private System.Windows.Forms.Label labelSets;
+        private XPTable.Models.Table tableSets;
+        private XPTable.Models.ColumnModel columnModelNuclides;
+        private XPTable.Models.CheckBoxColumn columnNuclideIncluded;
+        private XPTable.Models.TextColumn columnNuclideName;
+        private XPTable.Models.TextColumn columnNuclideEnergy;
+        private XPTable.Models.ColumnModel columnModelSets;
+        private XPTable.Models.TextColumn columnSetName;
+        private XPTable.Models.TableModel tableModelSets;
+        private XPTable.Models.TableModel tableModelNuclides;
+        private XPTable.Models.CheckBoxColumn columnSetHideUnknown;
+    }
+}

--- a/BecquerelMonitor/NuclideSetForm.cs
+++ b/BecquerelMonitor/NuclideSetForm.cs
@@ -1,0 +1,265 @@
+﻿using BecquerelMonitor.Properties;
+using System;
+using System.Windows.Forms;
+using Windows.UI.Notifications;
+using XPTable.Models;
+
+namespace BecquerelMonitor
+{
+    public partial class NuclideSetForm : Form
+    {
+        private const int NuclideCheckboxColumnIndex = 0;
+        private const int SetNameColumnIndex = 0;
+        private const int SetHidePeaksColumnIndex = 1;
+
+        bool dirty = false;
+        NuclideSet selectedSet = null;
+        NuclideDefinitionManager nuclideManager = NuclideDefinitionManager.GetInstance();
+        MainForm mainForm;
+
+        public NuclideSetForm(MainForm mainForm)
+        {
+            InitializeComponent();
+
+            this.mainForm = mainForm;
+            this.Icon = Resources.becqmoni;
+            this.UpdateTableNuclides();
+            this.RenderTableSets();
+        }
+
+        private void UpdateTableNuclides()
+        {
+            this.tableNuclides.SuspendLayout();
+            this.tableModelNuclides.Rows.Clear();
+            this.nuclideManager.NuclideDefinitions.Sort();
+            
+            if (this.selectedSet != null)
+            {
+                foreach (NuclideDefinition nuclideDefinition in this.nuclideManager.NuclideDefinitions)
+                {
+                    Row row = new Row();
+                    bool included = nuclideDefinition.Sets.Contains(this.selectedSet.Id);
+                    row.Cells.Add(new Cell() { Checked = included });
+                    row.Cells.Add(new Cell(nuclideDefinition.Name));
+                    row.Cells.Add(new Cell(nuclideDefinition.Energy.ToString(), nuclideDefinition.Energy));
+                    this.tableModelNuclides.Rows.Add(row);
+                }
+            }
+
+            this.tableNuclides.ResumeLayout();
+        }
+
+        private void RenderTableSets()
+        {
+            this.tableSets.SuspendLayout();
+            this.tableModelSets.Rows.Clear();
+
+            foreach (NuclideSet nuclideSet in this.nuclideManager.NuclideSets)
+            {
+                Row row = this.CreateNuclideSetRow(nuclideSet);
+                this.tableModelSets.Rows.Add(row);
+            }
+
+            this.tableSets.ResumeLayout();
+        }
+
+        private void buttonAddSet_Click(object sender, EventArgs e)
+        {
+            NuclideSet set = new NuclideSet()
+            {
+                Id = Guid.NewGuid(),
+                Name = $"New set {this.tableModelSets.Rows.Count + 1}"
+            };
+
+            this.tableSets.SuspendLayout();
+            Row row = this.CreateNuclideSetRow(set);
+            this.tableModelSets.Rows.Add(row);
+            this.tableSets.ResumeLayout();
+
+            this.nuclideManager.NuclideSets.Add(set);
+            this.MarkAsDirty();
+        }
+
+        private Row CreateNuclideSetRow(NuclideSet set)
+        {
+            Row row = new Row();
+            row.Cells.Add(new Cell(set.Name));
+            row.Cells.Add(new Cell() { Checked = set.HideUnknownPeaks });
+            return row;
+        }
+
+        private void tableSets_SelectionChanged(object sender, XPTable.Events.SelectionEventArgs e)
+        {
+            if (e.NewSelectedIndicies.Length > 0)
+            {
+                int newIndex = e.NewSelectedIndicies[0];
+                if (newIndex < this.nuclideManager.NuclideSets.Count)
+                {
+                    this.selectedSet = this.nuclideManager.NuclideSets[newIndex];
+                }
+                else
+                {
+                    this.selectedSet = null;
+                }
+            } 
+            else
+            {
+                this.selectedSet = null;
+            }
+
+            this.buttonDeleteSet.Enabled = this.selectedSet != null;
+            this.UpdateTableNuclides();
+        }
+
+        private void tableNuclides_CellClick(object sender, XPTable.Events.CellMouseEventArgs e)
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            if (e.Cell.Index == NuclideCheckboxColumnIndex)
+            {
+                bool include = !e.Cell.Checked;
+                this.UpdateNuclideDefinition(e.Row, include);
+            }
+        }
+
+        private void ToggleNuclideSelection()
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            this.tableNuclides.SuspendLayout();
+            Column checkCol = this.columnModelNuclides.Columns[NuclideCheckboxColumnIndex];
+            checkCol.Text = checkCol.Text == "X"
+                ? ""
+                : "X";
+
+            for (int i = 0; i < this.nuclideManager.NuclideDefinitions.Count; i++)
+            {
+                bool include = checkCol.Text == "X";
+                Row row = this.tableModelNuclides.Rows[i];
+                row.Cells[NuclideCheckboxColumnIndex].Checked = include;
+                this.UpdateNuclideDefinition(i, include);
+            }
+
+            this.tableNuclides.ResumeLayout();
+        }
+
+        private void UpdateNuclideDefinition(int index, bool include)
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            NuclideDefinition def = this.nuclideManager.NuclideDefinitions[index];
+            if (include)
+            {
+                def.Sets.Add(this.selectedSet.Id);
+            }
+            else
+            {
+                def.Sets.Remove(this.selectedSet.Id);
+            }
+
+            this.MarkAsDirty();
+        }
+
+        private void tableNuclides_HeaderClick(object sender, XPTable.Events.HeaderMouseEventArgs e)
+        {
+            if (e.Index == NuclideCheckboxColumnIndex)
+            {
+                ToggleNuclideSelection();
+            }
+        }
+
+        private void MarkAsDirty()
+        {
+            this.buttonSave.Enabled = true;
+            this.dirty = true;
+        }
+
+        private void buttonSave_Click(object sender, EventArgs e)
+        {
+            this.nuclideManager.SaveDefinitionFile();
+            this.dirty = false;
+            this.buttonSave.Enabled = false;
+        }
+
+        private void buttonDeleteSet_Click(object sender, EventArgs e)
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            int indexToRemove = this.nuclideManager.NuclideSets.IndexOf(this.selectedSet);
+            if (indexToRemove > -1)
+            {
+                this.nuclideManager.NuclideSets.RemoveAt(indexToRemove);
+                foreach (NuclideDefinition nuclide in this.nuclideManager.NuclideDefinitions)
+                {
+                    nuclide.Sets.Remove(this.selectedSet.Id);
+                }
+
+                this.tableSets.SuspendLayout();
+                this.tableModelSets.Rows.RemoveAt(indexToRemove);
+                this.tableSets.ResumeLayout();
+
+                this.selectedSet = null;
+                this.MarkAsDirty();
+            }
+        }
+
+        private void buttonClose_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        private void NuclideSetForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (this.dirty)
+            {
+                DialogResult dialogResult = MessageBox.Show(Resources.MSGSavingNuclideSet, Resources.ConfirmationDialogTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation);
+                if (dialogResult == DialogResult.Yes)
+                {
+                    this.nuclideManager.SaveDefinitionFile();
+                }
+            }
+
+            this.mainForm.RefresNuclideSetList();
+        }
+
+        private void tableSets_EditingStopped(object sender, XPTable.Events.CellEditEventArgs e)
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            if (e.Cell.Index == SetNameColumnIndex)
+            {
+                this.selectedSet.Name = e.Cell.Text;
+                this.MarkAsDirty();
+            }
+        }
+
+        private void tableSets_CellCheckChanged(object sender, XPTable.Events.CellCheckBoxEventArgs e)
+        {
+            if (this.selectedSet == null)
+            {
+                return;
+            }
+
+            if (e.Cell.Index == SetHidePeaksColumnIndex)
+            {
+                this.selectedSet.HideUnknownPeaks = e.Cell.Checked;
+                this.MarkAsDirty();
+            }
+        }
+    }
+}

--- a/BecquerelMonitor/NuclideSetForm.resx
+++ b/BecquerelMonitor/NuclideSetForm.resx
@@ -1,0 +1,468 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LabelNewSetText" xml:space="preserve">
+    <value>New set {0}</value>
+  </data>
+  <data name="buttonAddSet.Text" xml:space="preserve">
+    <value>Add new set</value>
+  </data>
+  <data name="buttonDeleteSet.Text" xml:space="preserve">
+    <value>Delete set</value>
+  </data>
+  <data name="buttonSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="buttonClose.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="columnSetName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="columnSetHideUnknown.Text" xml:space="preserve">
+    <value>Hide unknown peaks</value>
+  </data>
+  <data name="columnNuclideName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="columnNuclideEnergy.Text" xml:space="preserve">
+    <value>Energy</value>
+  </data>
+  <data name="labelNuclides.Text" xml:space="preserve">
+    <value>Mark nuclides included in set</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="columnModelNuclides.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>17, 17</value>
+  </data>
+  <data name="tableModelNuclides.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>192, 17</value>
+  </data>
+  <data name="columnModelSets.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>352, 17</value>
+  </data>
+  <data name="tableModelSets.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>502, 17</value>
+  </data>
+  <data name="&gt;&gt;buttonDeleteSet.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="buttonDeleteSet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 23</value>
+  </data>
+  <data name="&gt;&gt;tableSets.Type" xml:space="preserve">
+    <value>XPTable.Models.Table, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="buttonDeleteSet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>167, 414</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="columnNuclideEnergy.Width" type="System.Int32, mscorlib">
+    <value>70</value>
+  </data>
+  <assembly alias="BecquerelMonitor" name="BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null" />
+  <!--<data name="columnNuclideEnergy.Alignment" type="XPTable.Models.ColumnAlignment, BecquerelMonitor">
+    <value>Right</value>
+  </data>-->
+  <data name="&gt;&gt;labelNuclides.Name" xml:space="preserve">
+    <value>labelNuclides</value>
+  </data>
+  <data name="&gt;&gt;groupBoxEdit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideEnergy.Type" xml:space="preserve">
+    <value>XPTable.Models.TextColumn, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;buttonAddSet.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tableSets.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="labelSets.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="buttonDeleteSet.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;tableSets.Name" xml:space="preserve">
+    <value>tableSets</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;labelSets.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelNuclides.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tableModelSets.Name" xml:space="preserve">
+    <value>tableModelSets</value>
+  </data>
+  <data name="labelNuclides.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 13</value>
+  </data>
+  <data name="buttonSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>359, 464</value>
+  </data>
+  <data name="&gt;&gt;buttonDeleteSet.Name" xml:space="preserve">
+    <value>buttonDeleteSet</value>
+  </data>
+  <data name="tableSets.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 34</value>
+  </data>
+  <data name="&gt;&gt;groupBoxEdit.Name" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="&gt;&gt;columnModelNuclides.Type" xml:space="preserve">
+    <value>XPTable.Models.ColumnModel, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;tableModelNuclides.Name" xml:space="preserve">
+    <value>tableModelNuclides</value>
+  </data>
+  <data name="tableNuclides.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
+    <value>453, 464</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideName.Type" xml:space="preserve">
+    <value>XPTable.Models.TextColumn, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;labelSets.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideEnergy.Name" xml:space="preserve">
+    <value>columnNuclideEnergy</value>
+  </data>
+  <data name="&gt;&gt;buttonDeleteSet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="tableSets.Size" type="System.Drawing.Size, System.Drawing">
+    <value>266, 374</value>
+  </data>
+  <data name="&gt;&gt;columnSetName.Type" xml:space="preserve">
+    <value>XPTable.Models.TextColumn, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="buttonAddSet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>54, 414</value>
+  </data>
+  <data name="tableNuclides.Size" type="System.Drawing.Size, System.Drawing">
+    <value>218, 405</value>
+  </data>
+  <data name="&gt;&gt;columnModelSets.Name" xml:space="preserve">
+    <value>columnModelSets</value>
+  </data>
+  <data name="&gt;&gt;buttonAddSet.Name" xml:space="preserve">
+    <value>buttonAddSet</value>
+  </data>
+  <data name="buttonClose.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 23</value>
+  </data>
+  <data name="columnNuclideName.Width" type="System.Int32, mscorlib">
+    <value>110</value>
+  </data>
+  <data name="buttonAddSet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Edit Nuclide Sets</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.Name" xml:space="preserve">
+    <value>buttonSave</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;columnModelSets.Type" xml:space="preserve">
+    <value>XPTable.Models.ColumnModel, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="tableSets.Text" xml:space="preserve">
+    <value>tableSets</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideIncluded.Type" xml:space="preserve">
+    <value>XPTable.Models.CheckBoxColumn, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="labelNuclides.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <!--<data name="columnNuclideIncluded.Alignment" type="XPTable.Models.ColumnAlignment, BecquerelMonitor">
+    <value>Center</value>
+  </data>-->
+  <data name="&gt;&gt;columnSetHideUnknown.Name" xml:space="preserve">
+    <value>columnSetHideUnknown</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideName.Name" xml:space="preserve">
+    <value>columnNuclideName</value>
+  </data>
+  <data name="buttonDeleteSet.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;tableModelNuclides.Type" xml:space="preserve">
+    <value>XPTable.Models.TableModel, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;buttonAddSet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnNuclideIncluded.Name" xml:space="preserve">
+    <value>columnNuclideIncluded</value>
+  </data>
+  <data name="&gt;&gt;tableSets.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;tableNuclides.Type" xml:space="preserve">
+    <value>XPTable.Models.Table, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="tableNuclides.Text" xml:space="preserve">
+    <value>Nuclides</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>547, 496</value>
+  </data>
+  <data name="buttonAddSet.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;tableNuclides.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="buttonSave.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="groupBoxEdit.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="groupBoxEdit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 5</value>
+  </data>
+  <data name="&gt;&gt;labelNuclides.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="labelSets.Text" xml:space="preserve">
+    <value>Select nuclide set</value>
+  </data>
+  <data name="&gt;&gt;buttonAddSet.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;labelSets.Name" xml:space="preserve">
+    <value>labelSets</value>
+  </data>
+  <data name="&gt;&gt;groupBoxEdit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelSets.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;groupBoxEdit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonDeleteSet.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;columnModelNuclides.Name" xml:space="preserve">
+    <value>columnModelNuclides</value>
+  </data>
+  <data name="buttonSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 23</value>
+  </data>
+  <data name="labelNuclides.Location" type="System.Drawing.Point, System.Drawing">
+    <value>291, 18</value>
+  </data>
+  <data name="tableSets.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>NuclideSetForm</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="columnNuclideIncluded.Width" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;labelNuclides.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="labelSets.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 13</value>
+  </data>
+  <data name="&gt;&gt;tableNuclides.Parent" xml:space="preserve">
+    <value>groupBoxEdit</value>
+  </data>
+  <data name="labelNuclides.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelSets.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Name" xml:space="preserve">
+    <value>buttonClose</value>
+  </data>
+  <data name="tableNuclides.Location" type="System.Drawing.Point, System.Drawing">
+    <value>293, 34</value>
+  </data>
+  <data name="columnSetName.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
+  <data name="&gt;&gt;columnSetName.Name" xml:space="preserve">
+    <value>columnSetName</value>
+  </data>
+  <data name="&gt;&gt;tableNuclides.Name" xml:space="preserve">
+    <value>tableNuclides</value>
+  </data>
+  <data name="&gt;&gt;tableModelSets.Type" xml:space="preserve">
+    <value>XPTable.Models.TableModel, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="groupBoxEdit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>523, 449</value>
+  </data>
+  <data name="columnSetHideUnknown.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
+  <data name="&gt;&gt;columnSetHideUnknown.Type" xml:space="preserve">
+    <value>XPTable.Models.CheckBoxColumn, BecquerelMonitor, Version=2024.9.6.4, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="labelSets.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 18</value>
+  </data>
+  <data name="buttonSave.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+</root>

--- a/BecquerelMonitor/NuclideSetForm.ru.resx
+++ b/BecquerelMonitor/NuclideSetForm.ru.resx
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LabelNewSetText" xml:space="preserve">
+    <value>Новый набор {0}</value>
+  </data>
+  <data name="buttonAddSet.Text" xml:space="preserve">
+    <value>Добавить набор</value>
+  </data>
+  <data name="buttonDeleteSet.Text" xml:space="preserve">
+    <value>Удалить набор</value>
+  </data>
+  <data name="buttonSave.Text" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="buttonClose.Text" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="columnSetName.Text" xml:space="preserve">
+    <value>Имя</value>
+  </data>
+  <data name="columnSetHideUnknown.Text" xml:space="preserve">
+    <value>Скрыть неизв. пики</value>
+  </data>
+  <data name="columnNuclideName.Text" xml:space="preserve">
+    <value>Имя</value>
+  </data>
+  <data name="columnNuclideEnergy.Text" xml:space="preserve">
+    <value>Энергия</value>
+  </data>
+  <data name="labelNuclides.Text" xml:space="preserve">
+    <value>Отметить изотопы входящие в набор</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Редактировать наборы изотопов</value>
+  </data>
+  <data name="labelSets.Text" xml:space="preserve">
+    <value>Выбрать набор изотопов</value>
+  </data>
+</root>

--- a/BecquerelMonitor/Properties/Resources.Designer.cs
+++ b/BecquerelMonitor/Properties/Resources.Designer.cs
@@ -1838,6 +1838,15 @@ namespace BecquerelMonitor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nuclide set(s) has been modified. Save?.
+        /// </summary>
+        internal static string MSGSavingNuclideSet {
+            get {
+                return ResourceManager.GetString("MSGSavingNuclideSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changing thermometer type causes initialization of input fields. OK?.
         /// </summary>
         internal static string MSGThermometerTypeChanging {

--- a/BecquerelMonitor/Properties/Resources.resx
+++ b/BecquerelMonitor/Properties/Resources.resx
@@ -145,6 +145,9 @@
   <data name="MSGSavingNuclideDefinition" xml:space="preserve">
     <value>Nuclide definition has been modified. Save?</value>
   </data>
+  <data name="MSGSavingNuclideSet" xml:space="preserve">
+    <value>Nuclide set(s) has been modified. Save?</value>
+  </data>
   <data name="ERRDeviceConfigNotSelected" xml:space="preserve">
     <value>Device configuration is not selected.</value>
   </data>

--- a/BecquerelMonitor/Properties/Resources.ru.resx
+++ b/BecquerelMonitor/Properties/Resources.ru.resx
@@ -617,6 +617,9 @@ http://xptable.sourceforge.net/</value>
   <data name="MSGSavingNuclideDefinition" xml:space="preserve">
     <value>Библиотека изотопов была изменена. Сохранить?</value>
   </data>
+  <data name="MSGSavingNuclideSet" xml:space="preserve">
+    <value>Набор(ы) изотопов был изменен. Сохранить?</value>
+  </data>
   <data name="MSGThermometerTypeChanging" xml:space="preserve">
     <value>Изменение типа термометра приведёт к реинициализации всех полей. ОК?</value>
   </data>


### PR DESCRIPTION
- nuclide set concept for peak search:
  - nuclide name is taken from set, not from all the definitions
  - there is an option to hide unknown/unmatched peaks
- store sets in nuclide definition file (nuclide references sets)
- create separate dialog to manage sets
- add set selector to peak find results window

![image](https://github.com/user-attachments/assets/45bd831e-b5ab-4e36-83ab-84b926e2beac)
![image](https://github.com/user-attachments/assets/8b105131-2458-4348-b413-7a676f118f4f)
![image](https://github.com/user-attachments/assets/2e27aaae-2c38-4fdc-8839-74d54c2a22b8)
