### PR TITLE
feat (smooth): add progressive smooth option

### DIFF
--- a/BecquerelMonitor/ChartViewConfig.cs
+++ b/BecquerelMonitor/ChartViewConfig.cs
@@ -294,6 +294,18 @@
             }
         }
 
+        public bool ProgresiveSmooth
+        {
+            get
+            {
+                return this.progressiveSmooth;
+            }
+            set
+            {
+                this.progressiveSmooth = value;
+            }
+        }
+
         public double HorizontalScale
         {
             get
@@ -381,6 +393,8 @@
         int numberOfWMADataPoints = 11;
 
         int countlimit = 100;
+
+        bool progressiveSmooth = false;
 
         // Token: 0x040008DB RID: 2267
         int chartRefreshCycle = 500;

--- a/BecquerelMonitor/DocumentManager.cs
+++ b/BecquerelMonitor/DocumentManager.cs
@@ -1185,15 +1185,16 @@ namespace BecquerelMonitor
                 energySpectrum = doc.ActiveResultData.EnergySpectrum.Clone();
             }
             int countlimit = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.CountLimit;
+            bool progressiveSmooth = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.ProgresiveSmooth;
             switch (smoothMethod)
             {
                 case SmoothingMethod.SimpleMovingAverage:
                     int points = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.NumberOfSMADataPoints;
-                    dSpectrum = sa.SMA2(Array.ConvertAll(energySpectrum.Spectrum, i => (double)i), points, countlimit: countlimit);
+                    dSpectrum = sa.SMA2(Array.ConvertAll(energySpectrum.Spectrum, i => (double)i), points, countlimit: countlimit, progressive: progressiveSmooth);
                     break;
                 case SmoothingMethod.WeightedMovingAverage:
                     points = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.NumberOfWMADataPoints;
-                    dSpectrum = sa.WMA2(Array.ConvertAll(energySpectrum.Spectrum, i => (double)i), points, countlimit: countlimit);
+                    dSpectrum = sa.WMA2(Array.ConvertAll(energySpectrum.Spectrum, i => (double)i), points, countlimit: countlimit, progressive: progressiveSmooth);
                     break;
                 default:
                     dSpectrum = Array.ConvertAll(energySpectrum.Spectrum, i => (double)i);

--- a/BecquerelMonitor/EnergySpectrumView.Designer.cs
+++ b/BecquerelMonitor/EnergySpectrumView.Designer.cs
@@ -717,18 +717,19 @@ namespace BecquerelMonitor
                 SpectrumAriphmetics sa = new SpectrumAriphmetics();
                 int numberOfSMADataPoints = this.globalConfigManager.GlobalConfig.ChartViewConfig.NumberOfSMADataPoints;
                 int countlimit = this.globalConfigManager.GlobalConfig.ChartViewConfig.CountLimit;
+                bool progressiveSmooth = this.globalConfigManager.GlobalConfig.ChartViewConfig.ProgresiveSmooth;
                 foreach (ResultData resultData in this.resultDataList)
                 {
-                    resultData.EnergySpectrum.DrawingSpectrum = sa.SMA2(resultData.EnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit);
+                    resultData.EnergySpectrum.DrawingSpectrum = sa.SMA2(resultData.EnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
 
                 }
                 if (this.IsBackgroundVisible())
                 {
-                    this.backgroundEnergySpectrum.DrawingSpectrum = sa.SMA2(this.backgroundEnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit);
+                    this.backgroundEnergySpectrum.DrawingSpectrum = sa.SMA2(this.backgroundEnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
                 }
                 if (this.backgroundMode == BackgroundMode.ShowContinuum && this.continuumEnergySpectrum != null)
                 {
-                    this.continuumEnergySpectrum.DrawingSpectrum = sa.SMA2(this.continuumEnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit);
+                    this.continuumEnergySpectrum.DrawingSpectrum = sa.SMA2(this.continuumEnergySpectrum.DrawingSpectrum, numberOfSMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
                 }
                 sa.Dispose();
             }
@@ -737,17 +738,18 @@ namespace BecquerelMonitor
                 SpectrumAriphmetics sa = new SpectrumAriphmetics();
                 int numberOfWMADataPoints = this.globalConfigManager.GlobalConfig.ChartViewConfig.NumberOfWMADataPoints;
                 int countlimit = this.globalConfigManager.GlobalConfig.ChartViewConfig.CountLimit;
+                bool progressiveSmooth = this.globalConfigManager.GlobalConfig.ChartViewConfig.ProgresiveSmooth;
                 foreach (ResultData resultData in this.resultDataList)
                 {
-                    resultData.EnergySpectrum.DrawingSpectrum = sa.WMA2(resultData.EnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit);
+                    resultData.EnergySpectrum.DrawingSpectrum = sa.WMA2(resultData.EnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
                 }
                 if (this.IsBackgroundVisible())
                 {
-                    this.backgroundEnergySpectrum.DrawingSpectrum = sa.WMA2(this.backgroundEnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit);
+                    this.backgroundEnergySpectrum.DrawingSpectrum = sa.WMA2(this.backgroundEnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
                 }
                 if (this.backgroundMode == BackgroundMode.ShowContinuum && this.continuumEnergySpectrum != null)
                 {
-                    this.continuumEnergySpectrum.DrawingSpectrum = sa.WMA2(this.continuumEnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit);
+                    this.continuumEnergySpectrum.DrawingSpectrum = sa.WMA2(this.continuumEnergySpectrum.DrawingSpectrum, numberOfWMADataPoints, countlimit: countlimit, progressive: progressiveSmooth);
                 }
                 sa.Dispose();
             }

--- a/BecquerelMonitor/GlobalConfigForm.Designer.cs
+++ b/BecquerelMonitor/GlobalConfigForm.Designer.cs
@@ -77,6 +77,8 @@
 			this.numericUpDown9 = new global::System.Windows.Forms.NumericUpDown();
             this.numericUpDown13 = new global::System.Windows.Forms.NumericUpDown();
             this.numericUpDown14 = new global::System.Windows.Forms.NumericUpDown();
+            this.progressiveSmoothCheckbox = new global::System.Windows.Forms.CheckBox();
+            this.progressiveSmoothTooltip = new global::System.Windows.Forms.ToolTip();
             this.label58 = new global::System.Windows.Forms.Label();
 			this.label59 = new global::System.Windows.Forms.Label();
 			this.label60 = new global::System.Windows.Forms.Label();
@@ -297,6 +299,7 @@
 			this.groupBox2.Controls.Add(this.confidenceLevelcomboBox);
 			this.groupBox2.Controls.Add(this.confidenceLevelLabel);
             this.groupBox2.Controls.Add(this.numericUpDown13);
+            this.groupBox2.Controls.Add(this.progressiveSmoothCheckbox);
             this.groupBox2.Controls.Add(this.label90);
             this.groupBox2.Controls.Add(this.label28);
 			this.groupBox2.Controls.Add(this.label27);
@@ -370,6 +373,12 @@
             this.numericUpDown13.Maximum = decimal.MaxValue;
             this.numericUpDown13.Increment = 10;
             this.numericUpDown13.Value = 100;
+            resources.ApplyResources(this.progressiveSmoothCheckbox, "progressiveSmoothCheckbox");
+            this.progressiveSmoothCheckbox.Name = "progressiveSmoothCheckbox";
+            resources.ApplyResources(this.progressiveSmoothTooltip, "progressiveSmoothTooltip");
+            this.progressiveSmoothTooltip.IsBalloon = true;
+            this.progressiveSmoothTooltip.InitialDelay = 0;
+            this.progressiveSmoothTooltip.SetToolTip(this.progressiveSmoothCheckbox, this.progressiveSmoothCheckbox.Tag as string);
             resources.ApplyResources(this.label90, "label90");
             this.label90.Name = "label90";
             resources.ApplyResources(this.label28, "label28");
@@ -1636,6 +1645,9 @@
 		global::System.Windows.Forms.NumericUpDown numericUpDown9;
 
         global::System.Windows.Forms.NumericUpDown numericUpDown13;
+
+        global::System.Windows.Forms.CheckBox progressiveSmoothCheckbox;
+        global::System.Windows.Forms.ToolTip progressiveSmoothTooltip;
 
         // Token: 0x0400067B RID: 1659
         global::System.Windows.Forms.NumericUpDown numericUpDown6;

--- a/BecquerelMonitor/GlobalConfigForm.cs
+++ b/BecquerelMonitor/GlobalConfigForm.cs
@@ -80,6 +80,7 @@ namespace BecquerelMonitor
             this.numericUpDown1.Value = globalConfig.ChartViewConfig.NumberOfSMADataPoints;
             this.numericUpDown2.Value = globalConfig.ChartViewConfig.NumberOfWMADataPoints;
             this.numericUpDown13.Value = (int)globalConfig.ChartViewConfig.CountLimit;
+            this.progressiveSmoothCheckbox.Checked = globalConfig.ChartViewConfig.ProgresiveSmooth;
             this.numericUpDown3.Value = globalConfig.ChartViewConfig.ChartRefreshCycle;
             this.numericUpDown10.Value = (int)globalConfig.AutosavePeriod;
             this.numericUpDown14.Value = (decimal)globalConfig.ChartViewConfig.HorizontalScale;
@@ -206,6 +207,7 @@ namespace BecquerelMonitor
             globalConfig.ChartViewConfig.NumberOfSMADataPoints = (int)this.numericUpDown1.Value;
             globalConfig.ChartViewConfig.NumberOfWMADataPoints = (int)this.numericUpDown2.Value;
             globalConfig.ChartViewConfig.CountLimit = (int)this.numericUpDown13.Value;
+            globalConfig.ChartViewConfig.ProgresiveSmooth = this.progressiveSmoothCheckbox.Checked;
             globalConfig.ChartViewConfig.ChartRefreshCycle = (int)this.numericUpDown3.Value;
             globalConfig.ChartViewConfig.MagnificationReference = (MagnificationReference)this.comboBox11.SelectedIndex;
             globalConfig.ChartViewConfig.ConfidenceLevel = ConfidenceLevel.z_score_single_side[this.confidenceLevelcomboBox.SelectedIndex];

--- a/BecquerelMonitor/GlobalConfigForm.resx
+++ b/BecquerelMonitor/GlobalConfigForm.resx
@@ -5784,4 +5784,18 @@
   <data name="importSpectrumWithEmptyConfigCheckBox.Text" xml:space="preserve">
     <value>Set empty configuration for imported spectrums</value>
   </data>
+  <data name="progressiveSmoothCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+	<value>175, 18</value>
+  </data>
+  <data name="progressiveSmoothCheckbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 74</value>
+  </data>
+  <data name="progressiveSmoothCheckbox.Text" xml:space="preserve">
+    <value>Progressive Window Size</value>
+  </data>
+  <data name="progressiveSmoothCheckbox.Tag" xml:space="preserve">
+    <value>Setting above is applied to the middle of the spectrum
+Window size increases with channel number (from 0 at zero channel to 1.4x at spectrum end)
+Formula: size = middle_size * sqrt(channel_index / (channel_count / 2))</value>
+  </data>
 </root>

--- a/BecquerelMonitor/GlobalConfigForm.ru.resx
+++ b/BecquerelMonitor/GlobalConfigForm.ru.resx
@@ -2958,4 +2958,12 @@
   <data name="importSpectrumWithEmptyConfigCheckBox.Text" xml:space="preserve">
     <value>Устанавливать пустую конфигурацию импортируемым спектрам</value>
   </data>
+  <data name="progressiveSmoothCheckbox.Text" xml:space="preserve">
+    <value>Прогрессивный размер окна</value>
+  </data>
+  <data name="progressiveSmoothCheckbox.Tag" xml:space="preserve">
+    <value>Установка выше применяется к середине спектра
+Размер окна растет с ростом номера канала (от 0 для нулевого канала до 1.4x в конце спектра)
+Формула: size = middle_size * sqrt(channel_index / (channel_count / 2))</value>
+  </data>
 </root>

--- a/BecquerelMonitor/PeakDetector.cs
+++ b/BecquerelMonitor/PeakDetector.cs
@@ -23,15 +23,16 @@ namespace BecquerelMonitor
                 energySpectrum = resultData.EnergySpectrum.Clone();
             }
             int countlimit = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.CountLimit;
+            bool progressiveSmooth = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.ProgresiveSmooth;
             switch (smoothMethod)
             {
                 case SmoothingMethod.SimpleMovingAverage:
                     int points = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.NumberOfSMADataPoints;
-                    energySpectrum.Spectrum = sa.SMA(energySpectrum.Spectrum, points, countlimit: countlimit);
+                    energySpectrum.Spectrum = sa.SMA(energySpectrum.Spectrum, points, countlimit: countlimit, progressive: progressiveSmooth);
                     break;
                 case SmoothingMethod.WeightedMovingAverage:
                     points = GlobalConfigManager.GetInstance().GlobalConfig.ChartViewConfig.NumberOfWMADataPoints;
-                    energySpectrum.Spectrum = sa.WMA(energySpectrum.Spectrum, points, countlimit: countlimit);
+                    energySpectrum.Spectrum = sa.WMA(energySpectrum.Spectrum, points, countlimit: countlimit, progressive: progressiveSmooth);
                     break;
             }
 

--- a/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
+++ b/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
@@ -548,7 +548,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public double[] WMA2(double[] spectrum, int numberOfWMADataPoints, int countlimit = 100)
+        public double[] WMA2(double[] spectrum, int numberOfWMADataPoints, int countlimit = 100, bool progressive = false)
         {
             double[] result = new double[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>
@@ -556,7 +556,19 @@ namespace BecquerelMonitor.Utils
                 int window_size = 1;
                 if (spectrum[i] <= countlimit)
                 {
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)numberOfWMADataPoints) / (double)countlimit + (double)numberOfWMADataPoints);
+                    double pointsNum = numberOfWMADataPoints;
+                    if (progressive)
+                    {
+                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
+
+                        if (pointsNum < 1)
+                        {
+                            result[i] = spectrum[i];
+                            return;
+                        }
+                    }
+
+                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
                 }
                 if (window_size == 1)
                 {
@@ -566,7 +578,7 @@ namespace BecquerelMonitor.Utils
                 {
                     double part = 0.0;
                     double total = 0.0;
-                    for (int j = i - numberOfWMADataPoints / 2; j < i - numberOfWMADataPoints / 2 + numberOfWMADataPoints; j++)
+                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
                     {
                         int ch = j;
                         if (ch < 0)
@@ -577,7 +589,7 @@ namespace BecquerelMonitor.Utils
                         {
                             ch = spectrum.Length - 1;
                         }
-                        double weight = (double)(numberOfWMADataPoints / 2 + 1 - Math.Abs(i - ch));
+                        double weight = (double)(window_size / 2 + 1 - Math.Abs(i - ch));
                         part += (double)spectrum[ch] * weight;
                         total += weight;
                     }
@@ -587,7 +599,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public int[] WMA(int[] spectrum, int numberOfWMADataPoints, int countlimit = 100)
+        public int[] WMA(int[] spectrum, int numberOfWMADataPoints, int countlimit = 100, bool progressive = false)
         {
             int[] result = new int[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>
@@ -595,7 +607,19 @@ namespace BecquerelMonitor.Utils
                 int window_size = 1;
                 if (spectrum[i] <= countlimit)
                 {
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)numberOfWMADataPoints) / (double)countlimit + (double)numberOfWMADataPoints);
+                    double pointsNum = numberOfWMADataPoints;
+                    if (progressive)
+                    {
+                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
+
+                        if (pointsNum < 1)
+                        {
+                            result[i] = spectrum[i];
+                            return;
+                        }
+                    }
+
+                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
                 }
                 if (window_size == 1)
                 {
@@ -605,7 +629,7 @@ namespace BecquerelMonitor.Utils
                 {
                     double part = 0.0;
                     double total = 0.0;
-                    for (int j = i - numberOfWMADataPoints / 2; j < i - numberOfWMADataPoints / 2 + numberOfWMADataPoints; j++)
+                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
                     {
                         int ch = j;
                         if (ch < 0)
@@ -616,7 +640,7 @@ namespace BecquerelMonitor.Utils
                         {
                             ch = spectrum.Length - 1;
                         }
-                        double weight = (double)(numberOfWMADataPoints / 2 + 1 - Math.Abs(i - ch));
+                        double weight = (double)(window_size / 2 + 1 - Math.Abs(i - ch));
                         part += (double)spectrum[ch] * weight;
                         total += weight;
                     }
@@ -626,7 +650,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public double[] SMA2(double[] spectrum, int numberOfSMADataPoints, int countlimit = 100)
+        public double[] SMA2(double[] spectrum, int numberOfSMADataPoints, int countlimit = 100, bool progressive = true)
         {
             double[] result = new double[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>
@@ -635,7 +659,19 @@ namespace BecquerelMonitor.Utils
                 int window_size = 1;
                 if (spectrum[i] <= countlimit)
                 {
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)numberOfSMADataPoints) / (double)countlimit + (double)numberOfSMADataPoints);
+                    double pointsNum = numberOfSMADataPoints;
+                    if (progressive)
+                    {
+                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
+
+                        if (pointsNum < 1)
+                        {
+                            result[i] = spectrum[i];
+                            return;
+                        }
+                    }
+
+                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
                 }
                 if (window_size == 1)
                 {
@@ -662,7 +698,7 @@ namespace BecquerelMonitor.Utils
             return result;
         }
 
-        public int[] SMA(int[] spectrum, int numberOfSMADataPoints, int countlimit = 100)
+        public int[] SMA(int[] spectrum, int numberOfSMADataPoints, int countlimit = 100, bool progressive = false)
         {
             int[] result = new int[spectrum.Length];
             Parallel.For(0, spectrum.Length, i =>
@@ -671,7 +707,19 @@ namespace BecquerelMonitor.Utils
                 int window_size = 1;
                 if (spectrum[i] <= countlimit)
                 {
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)numberOfSMADataPoints) / (double)countlimit + (double)numberOfSMADataPoints);
+                    double pointsNum = numberOfSMADataPoints;
+                    if (progressive)
+                    {
+                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
+
+                        if (pointsNum < 1)
+                        {
+                            result[i] = spectrum[i];
+                            return;
+                        }
+                    }
+
+                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
                 }
                 if (window_size == 1)
                 {

--- a/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
+++ b/BecquerelMonitor/Utils/SpectrumAriphmetics.cs
@@ -551,199 +551,236 @@ namespace BecquerelMonitor.Utils
         public double[] WMA2(double[] spectrum, int numberOfWMADataPoints, int countlimit = 100, bool progressive = false)
         {
             double[] result = new double[spectrum.Length];
-            Parallel.For(0, spectrum.Length, i =>
+            if (progressive)
             {
-                int window_size = 1;
-                if (spectrum[i] <= countlimit)
+                Parallel.For(0, spectrum.Length, i =>
                 {
-                    double pointsNum = numberOfWMADataPoints;
-                    if (progressive)
+                    double pointsnum = GetProgressivePointsNum(i, spectrum.Length, numberOfWMADataPoints);
+                    if (pointsnum < 1)
                     {
-                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
-
-                        if (pointsNum < 1)
-                        {
-                            result[i] = spectrum[i];
-                            return;
-                        }
+                        result[i] = spectrum[i];
+                        return;
                     }
 
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
-                }
-                if (window_size == 1)
-                {
-                    result[i] = spectrum[i];
-                }
-                else
-                {
-                    double part = 0.0;
-                    double total = 0.0;
-                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+                    int window_size = GetWindowSize(spectrum[i], countlimit, pointsnum);
+                    if (window_size == 1)
                     {
-                        int ch = j;
-                        if (ch < 0)
-                        {
-                            ch = 0;
-                        }
-                        else if (ch >= spectrum.Length)
-                        {
-                            ch = spectrum.Length - 1;
-                        }
-                        double weight = (double)(window_size / 2 + 1 - Math.Abs(i - ch));
-                        part += (double)spectrum[ch] * weight;
-                        total += weight;
+                        result[i] = spectrum[i];
+                        return;
                     }
-                    result[i] = part / total;
-                }
-            });
+
+                    result[i] = GetWMAPointValue(spectrum, i, window_size);
+                });
+            }
+            else
+            {
+                Parallel.For(0, spectrum.Length, i =>
+                {
+                    int window_size = GetWindowSize(spectrum[i], countlimit, numberOfWMADataPoints);
+                    if (window_size == 1)
+                    {
+                        result[i] = spectrum[i];
+                    }
+                    else
+                    {
+                        result[i] = GetWMAPointValue(spectrum, i, window_size);
+                    }
+                });
+            }
+            
             return result;
         }
 
         public int[] WMA(int[] spectrum, int numberOfWMADataPoints, int countlimit = 100, bool progressive = false)
         {
             int[] result = new int[spectrum.Length];
-            Parallel.For(0, spectrum.Length, i =>
+            if (progressive)
             {
-                int window_size = 1;
-                if (spectrum[i] <= countlimit)
+                Parallel.For(0, spectrum.Length, i =>
                 {
-                    double pointsNum = numberOfWMADataPoints;
-                    if (progressive)
+                    double pointsnum = GetProgressivePointsNum(i, spectrum.Length, numberOfWMADataPoints);
+                    if (pointsnum < 1)
                     {
-                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
-
-                        if (pointsNum < 1)
-                        {
-                            result[i] = spectrum[i];
-                            return;
-                        }
+                        result[i] = spectrum[i];
+                        return;
                     }
 
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
-                }
-                if (window_size == 1)
-                {
-                    result[i] = spectrum[i];
-                }
-                else
-                {
-                    double part = 0.0;
-                    double total = 0.0;
-                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+                    int window_size = GetWindowSize(spectrum[i], countlimit, pointsnum);
+                    if (window_size == 1)
                     {
-                        int ch = j;
-                        if (ch < 0)
-                        {
-                            ch = 0;
-                        }
-                        else if (ch >= spectrum.Length)
-                        {
-                            ch = spectrum.Length - 1;
-                        }
-                        double weight = (double)(window_size / 2 + 1 - Math.Abs(i - ch));
-                        part += (double)spectrum[ch] * weight;
-                        total += weight;
+                        result[i] = spectrum[i];
+                        return;
                     }
-                    result[i] = Convert.ToInt32(part / total);
-                }
-            });
+
+                    result[i] = Convert.ToInt32(GetWMAPointValue(spectrum, i, window_size));
+                });
+            }
+            else
+            {
+                Parallel.For(0, spectrum.Length, i =>
+                {
+                    int window_size = GetWindowSize(spectrum[i], countlimit, numberOfWMADataPoints);
+                    if (window_size == 1)
+                    {
+                        result[i] = spectrum[i];
+                    }
+                    else
+                    {
+                        result[i] = Convert.ToInt32(GetWMAPointValue(spectrum, i, window_size));
+                    }
+                });
+            }
+
             return result;
         }
 
         public double[] SMA2(double[] spectrum, int numberOfSMADataPoints, int countlimit = 100, bool progressive = true)
         {
             double[] result = new double[spectrum.Length];
-            Parallel.For(0, spectrum.Length, i =>
+            if (progressive)
             {
-                double new_count = 0.0;
-                int window_size = 1;
-                if (spectrum[i] <= countlimit)
+                Parallel.For(0, spectrum.Length, i =>
                 {
-                    double pointsNum = numberOfSMADataPoints;
-                    if (progressive)
+                    double pointsnum = GetProgressivePointsNum(i, spectrum.Length, numberOfSMADataPoints);
+                    if (pointsnum < 1)
                     {
-                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
-
-                        if (pointsNum < 1)
-                        {
-                            result[i] = spectrum[i];
-                            return;
-                        }
+                        result[i] = spectrum[i];
+                        return;
                     }
 
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
-                }
-                if (window_size == 1)
-                {
-                    result[i] = spectrum[i];
-                }
-                else
-                {
-                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+                    int window_size = GetWindowSize(spectrum[i], countlimit, pointsnum);
+                    if (window_size == 1)
                     {
-                        int ch = j;
-                        if (ch < 0)
-                        {
-                            ch = 0;
-                        }
-                        else if (ch >= spectrum.Length)
-                        {
-                            ch = spectrum.Length - 1;
-                        }
-                        new_count += (double)spectrum[ch];
+                        result[i] = spectrum[i];
+                        return;
                     }
-                    result[i] = new_count / (double)window_size;
-                }
-            });
+
+                    double new_count = GetSMAPointValue(spectrum, i, window_size);
+                    result[i] = new_count / window_size;
+                });
+            }
+            else
+            {
+                Parallel.For(0, spectrum.Length, i =>
+                {
+                    int window_size = GetWindowSize(spectrum[i], countlimit, numberOfSMADataPoints);
+                    if (window_size == 1)
+                    {
+                        result[i] = spectrum[i];
+                    }
+                    else
+                    {
+                        double new_count = GetSMAPointValue(spectrum, i, window_size);
+                        result[i] = new_count / window_size;
+                    }
+                });
+            }
+
             return result;
         }
 
         public int[] SMA(int[] spectrum, int numberOfSMADataPoints, int countlimit = 100, bool progressive = false)
         {
             int[] result = new int[spectrum.Length];
-            Parallel.For(0, spectrum.Length, i =>
+            if (progressive)
             {
-                double new_count = 0.0;
-                int window_size = 1;
-                if (spectrum[i] <= countlimit)
+                Parallel.For(0, spectrum.Length, i =>
                 {
-                    double pointsNum = numberOfSMADataPoints;
-                    if (progressive)
+                    double pointsnum = GetProgressivePointsNum(i, spectrum.Length, numberOfSMADataPoints);
+                    if (pointsnum < 1)
                     {
-                        pointsNum *= Math.Sqrt(i / (spectrum.Length / 2.0));
-
-                        if (pointsNum < 1)
-                        {
-                            result[i] = spectrum[i];
-                            return;
-                        }
+                        result[i] = spectrum[i];
+                        return;
                     }
 
-                    window_size = Convert.ToInt32((double)spectrum[i] * (1 - (double)pointsNum) / (double)countlimit + (double)pointsNum);
-                }
-                if (window_size == 1)
-                {
-                    result[i] = spectrum[i];
-                }
-                else
-                {
-                    for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+                    int window_size = GetWindowSize(spectrum[i], countlimit, pointsnum);
+                    if (window_size == 1)
                     {
-                        int ch = j;
-                        if (ch < 0)
-                        {
-                            ch = 0;
-                        }
-                        else if (ch >= spectrum.Length)
-                        {
-                            ch = spectrum.Length - 1;
-                        }
-                        new_count += (double)spectrum[ch];
+                        result[i] = spectrum[i];
+                        return;
                     }
-                    result[i] = Convert.ToInt32(new_count / (double)window_size);
-                }
-            });
+
+                    double new_count = GetSMAPointValue(spectrum, i, window_size);
+                    result[i] = Convert.ToInt32(new_count / window_size);
+                });
+            }
+            else
+            {
+                Parallel.For(0, spectrum.Length, i =>
+                {
+                    int window_size = GetWindowSize(spectrum[i], countlimit, numberOfSMADataPoints);
+                    if (window_size == 1)
+                    {
+                        result[i] = spectrum[i];
+                    }
+                    else
+                    {
+                        double new_count = GetSMAPointValue(spectrum, i, window_size);
+                        result[i] = Convert.ToInt32(new_count / window_size);
+                    }
+                });
+            }
+            
             return result;
+        }
+
+        private static double GetSMAPointValue<T>(T[] spectrum, int i, int window_size)
+        {
+            double new_count = 0.0;
+            for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+            {
+                int ch = j;
+                if (ch < 0)
+                {
+                    ch = 0;
+                }
+                else if (ch >= spectrum.Length)
+                {
+                    ch = spectrum.Length - 1;
+                }
+                new_count += Convert.ToDouble(spectrum[ch]);
+            }
+
+            return new_count;
+        }
+
+        private static double GetWMAPointValue<T>(T[] spectrum, int i, int window_size)
+        {
+            double part = 0.0;
+            double total = 0.0;
+            for (int j = i - window_size / 2; j < i - window_size / 2 + window_size; j++)
+            {
+                int ch = j;
+                if (ch < 0)
+                {
+                    ch = 0;
+                }
+                else if (ch >= spectrum.Length)
+                {
+                    ch = spectrum.Length - 1;
+                }
+                double weight = (double)(window_size / 2 + 1 - Math.Abs(i - ch));
+                part += Convert.ToDouble(spectrum[ch]) * weight;
+                total += weight;
+            }
+            double value = part / total;
+            return value;
+        }
+
+        private static double GetProgressivePointsNum(int channelIndex, int channelCount, int numberOfDataPoints)
+        {
+            return numberOfDataPoints * Math.Sqrt(channelIndex / (channelCount / 2.0));
+        }
+
+        private static int GetWindowSize(double channelValue, int countlimit, double pointsNum)
+        {
+            int window_size = 1;
+            if (channelValue <= countlimit)
+            {
+                window_size = Convert.ToInt32(channelValue * (1 - pointsNum) / countlimit + pointsNum);
+            }
+
+            return window_size;
         }
 
         public void Dispose()


### PR DESCRIPTION
- with progressive smooth use different window size for different parts of spectrum
- window size for progressive mode is applied to middle of the spectrum
- size of window depends on square root of channel position relative to the middle of the spectrum

![image](https://github.com/user-attachments/assets/916197c3-7076-4275-beb4-67ff1feec51a)
![image](https://github.com/user-attachments/assets/ce102afc-38f3-4278-9a3e-9a7d892a62bd)
![image](https://github.com/user-attachments/assets/cadd1587-36f2-4a63-9ad1-2b9305f821af)
